### PR TITLE
Include default aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,12 @@ export default function laravel(config: string|string[]|Partial<PluginConfig>): 
     let viteDevServerUrl: string
     let resolvedConfig: ResolvedConfig
 
+    const ziggy = 'vendor/tightenco/ziggy/dist/index.es.js';
+    const defaultAliases: Record<string, string> = {
+        ...(fs.existsSync(ziggy) ? { ziggy } : undefined),
+        '@': '/resources/js',
+    };
+
     return {
         name: 'laravel',
         enforce: 'post',
@@ -80,10 +86,13 @@ export default function laravel(config: string|string[]|Partial<PluginConfig>): 
                     alias: Array.isArray(userConfig.resolve?.alias)
                         ? [
                             ...userConfig.resolve?.alias ?? [],
-                            { find: '@', replacement: '/resources/js' },
+                            ...Object.keys(defaultAliases).map(alias => ({
+                                find: alias,
+                                replacement: defaultAliases[alias]
+                            }))
                         ]
                         : {
-                            '@': '/resources/js',
+                            ...defaultAliases,
                             ...userConfig.resolve?.alias,
                         }
                 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, MockedFunction, vi } from 'vitest'
 import laravel from '../src'
+import fs from 'fs'
 
 describe('laravel-vite-plugin', () => {
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
     it('accepts a single input', () => {
         const plugin = laravel('resources/js/app.js')
 
@@ -165,6 +170,30 @@ describe('laravel-vite-plugin', () => {
             { find: '@', replacement: '/something/else' },
             { find: '@', replacement: '/resources/js' },
         ])
+    })
+
+    it('provides an ziggy alias when installed', () => {
+        vi.spyOn(fs, 'existsSync').mockReturnValueOnce(true)
+
+        const plugin = laravel('resources/js/app.js')
+
+        const config = plugin.config({}, { command: 'build', mode: 'development' })
+
+        expect(config.resolve.alias['ziggy']).toBe('vendor/tightenco/ziggy/dist/index.es.js')
+    })
+
+    it('provides an ziggy alias when installed and using an alias array', () => {
+        vi.spyOn(fs, 'existsSync').mockReturnValueOnce(true)
+
+        const plugin = laravel('resources/js/app.js')
+
+        const config = plugin.config({
+            resolve: {
+                alias: [],
+            }
+        }, { command: 'build', mode: 'development' })
+
+        expect(config.resolve.alias).toContainEqual({ find: 'ziggy', replacement: 'vendor/tightenco/ziggy/dist/index.es.js' })
     })
 
     it('prevents empty input', () => {


### PR DESCRIPTION
This PR updates the plugin to include a default resolve alias for `@` to `/resources/js`.

If the user provides their own `@` alias, theirs will take precedence.

Additionally, a `ziggy` alias is also included when the Ziggy is found in the vendor directory to facilitate zero-config Breeze SSR builds. Currently, this is included in the [stub](https://github.com/laravel/breeze/blob/ac7ba75d31040772013593582c7e7093ea7073c7/stubs/inertia-vue/webpack.ssr.mix.js#L12).