### PR TITLE
Provide default entrypoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ interface PluginConfig {
     /**
      * The path or path of the entry points to compile.
      *
-     * @example 'resources/js/app.js'
+     * @default 'resources/js/app.js'
      */
     input: string|string[]|undefined
 
@@ -29,7 +29,7 @@ interface PluginConfig {
     /**
      * The path of the SSR entry point.
      *
-     * @example 'resources/js/ssr.js'
+     * @default 'resources/js/ssr.js'
      */
     ssr: string|string[]|undefined
 
@@ -50,7 +50,7 @@ interface LaravelPlugin extends Plugin {
  *
  * @param config - A config object or relative path(s) of the scripts to be compiled.
  */
-export default function laravel(config: string|string[]|Partial<PluginConfig>): LaravelPlugin {
+export default function laravel(config?: string|string[]|Partial<PluginConfig>): LaravelPlugin {
     const pluginConfig = resolvePluginConfig(config)
     let viteDevServerUrl: string
     let resolvedConfig: ResolvedConfig
@@ -159,13 +159,9 @@ function laravelVersion(): string {
 /**
  * Convert the users configuration into a standard structure with defaults.
  */
-function resolvePluginConfig(config: string|string[]|Partial<PluginConfig>): PluginConfig {
-    if (config === undefined) {
-        throw new Error('Laravel plugin requires configuration.')
-    }
-
-    if (typeof config === 'string' || Array.isArray(config)) {
-        config = { input: config }
+function resolvePluginConfig(config?: string|string[]|Partial<PluginConfig>): PluginConfig {
+    if (typeof config === 'undefined' || typeof config === 'string' || Array.isArray(config)) {
+        config = { input: config, ssr: config }
     }
 
     if (typeof config.publicDirectory === 'string') {
@@ -189,10 +185,10 @@ function resolvePluginConfig(config: string|string[]|Partial<PluginConfig>): Plu
     }
 
     return {
-        input: config.input,
+        input: config.input ?? 'resources/js/app.js',
         publicDirectory: config.publicDirectory ?? 'public',
         buildDirectory: config.buildDirectory ?? 'build',
-        ssr: config.ssr,
+        ssr: config.ssr ?? 'resources/js/ssr.js',
         ssrOutputDirectory: config.ssrOutputDirectory ?? 'storage/ssr',
     }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, MockedFunction, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import laravel from '../src'
 import fs from 'fs'
 
@@ -7,70 +7,69 @@ describe('laravel-vite-plugin', () => {
         vi.clearAllMocks()
     })
 
-    it('accepts a single input', () => {
-        const plugin = laravel('resources/js/app.js')
-
-        const config = plugin.config({}, { command: 'build', mode: 'development' })
-
+    it('provides sensible default values', () => {
+        const plugin = laravel()
         expect(plugin.name).toBe('laravel')
-        expect(config.base).toBe('/build/')
-        expect(config.build?.manifest).toBe(true)
-        expect(config.build?.outDir).toBe('public/build')
-        expect(config.build?.rollupOptions?.input).toBe('resources/js/app.js')
 
-        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'development' })
+        const buildConfig = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(buildConfig.base).toBe('/build/')
+        expect(buildConfig.build.manifest).toBe(true)
+        expect(buildConfig.build.outDir).toBe('public/build')
+        expect(buildConfig.build.rollupOptions.input).toBe('resources/js/app.js')
 
+        const serveConfig = plugin.config({}, { command: 'serve', mode: 'development' })
+        expect(serveConfig.base).toBe('')
+
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/build/')
-        expect(ssrConfig.build?.manifest).toBe(false)
-        expect(ssrConfig.build?.outDir).toBe('storage/ssr')
-        expect(ssrConfig.build?.rollupOptions?.input).toBe('resources/js/app.js')
+        expect(ssrConfig.build.manifest).toBe(false)
+        expect(ssrConfig.build.outDir).toBe('storage/ssr')
+        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
+    })
+
+    it('accepts a single input', () => {
+        const plugin = laravel('resources/js/app.ts')
+
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
+
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
+        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/app.ts')
     })
 
     it('accepts an array of inputs', () => {
         const plugin = laravel([
-            'resources/js/app.js',
+            'resources/js/app.ts',
             'resources/js/other.js',
         ])
 
-        const config = plugin.config({}, { command: 'build', mode: 'development' })
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(config.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
 
-        expect(plugin.name).toBe('laravel')
-        expect(config.base).toBe('/build/')
-        expect(config.build?.manifest).toBe(true)
-        expect(config.build?.outDir).toBe('public/build')
-        expect(config.build?.rollupOptions?.input).toEqual(['resources/js/app.js', 'resources/js/other.js'])
-
-        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'development' })
-
-        expect(ssrConfig.base).toBe('/build/')
-        expect(ssrConfig.build?.manifest).toBe(false)
-        expect(ssrConfig.build?.outDir).toBe('storage/ssr')
-        expect(ssrConfig.build?.rollupOptions?.input).toEqual(['resources/js/app.js', 'resources/js/other.js'])
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
+        expect(ssrConfig.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
     })
 
     it('accepts a full configuration', () => {
         const plugin = laravel({
-            input: 'resources/js/app.js',
+            input: 'resources/js/app.ts',
             publicDirectory: 'other-public',
             buildDirectory: 'other-build',
-            ssr: 'resources/js/ssr.js',
+            ssr: 'resources/js/ssr.ts',
             ssrOutputDirectory: 'other-ssr-output',
         })
 
-        const config = plugin.config({}, { command: 'build', mode: 'development' })
-
-        expect(plugin.name).toBe('laravel')
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/other-build/')
-        expect(config.build?.manifest).toBe(true)
-        expect(config.build?.outDir).toBe('other-public/other-build')
-        expect(config.build?.rollupOptions?.input).toBe('resources/js/app.js')
+        expect(config.build.manifest).toBe(true)
+        expect(config.build.outDir).toBe('other-public/other-build')
+        expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
 
-        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'development' })
-
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/other-build/')
-        expect(ssrConfig.build?.manifest).toBe(false)
-        expect(ssrConfig.build?.outDir).toBe('other-ssr-output')
-        expect(ssrConfig.build?.rollupOptions?.input).toBe('resources/js/ssr.js')
+        expect(ssrConfig.build.manifest).toBe(false)
+        expect(ssrConfig.build.outDir).toBe('other-ssr-output')
+        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.ts')
     })
 
     it('accepts a partial configuration', () => {
@@ -79,28 +78,24 @@ describe('laravel-vite-plugin', () => {
             ssr: 'resources/js/ssr.js',
         })
 
-        const config = plugin.config({}, { command: 'build', mode: 'development' })
-
-        expect(plugin.name).toBe('laravel')
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/build/')
-        expect(config.build?.manifest).toBe(true)
-        expect(config.build?.outDir).toBe('public/build')
-        expect(config.build?.rollupOptions?.input).toBe('resources/js/app.js')
+        expect(config.build.manifest).toBe(true)
+        expect(config.build.outDir).toBe('public/build')
+        expect(config.build.rollupOptions.input).toBe('resources/js/app.js')
 
-        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'development' })
-
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/build/')
-        expect(ssrConfig.build?.manifest).toBe(false)
-        expect(ssrConfig.build?.outDir).toBe('storage/ssr')
-        expect(ssrConfig.build?.rollupOptions?.input).toBe('resources/js/ssr.js')
+        expect(ssrConfig.build.manifest).toBe(false)
+        expect(ssrConfig.build.outDir).toBe('storage/ssr')
+        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
     })
 
     it('prefixes the base with ASSET_URL', () => {
         process.env.ASSET_URL = 'http://example.com'
         const plugin = laravel('resources/js/app.js')
 
-        const config = plugin.config({}, { command: 'build', mode: 'development' })
-
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('http://example.com/build/')
 
         delete process.env.ASSET_URL
@@ -123,13 +118,11 @@ describe('laravel-vite-plugin', () => {
             ssrOutputDirectory: '/ssr-output/test/',
         })
 
-        const config = plugin.config({}, { command: 'build', mode: 'development' })
-
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/build/test/')
         expect(config.build.outDir).toBe('public/test/build/test')
 
-        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'development' })
-
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.build.outDir).toBe('ssr-output/test')
     })
 
@@ -194,12 +187,5 @@ describe('laravel-vite-plugin', () => {
         }, { command: 'build', mode: 'development' })
 
         expect(config.resolve.alias).toContainEqual({ find: 'ziggy', replacement: 'vendor/tightenco/ziggy/dist/index.es.js' })
-    })
-
-    it('prevents empty input', () => {
-        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-        /* @ts-ignore */
-        expect(() => laravel())
-            .toThrowError('Laravel plugin requires configuration.')
     })
 })


### PR DESCRIPTION
This PR updates the plugin to have default entry points, which allows for zero-config usage with Laravel's defaults.

```js
import { defineConfig } from 'vite'
import laravel from 'laravel-vite-plugin'

export default defineConfig({
    plugins: [
        laravel()
    ]
})
```

In this scenario, the regular entry point will be `resources/js/app.js` and the SSR entry point will be `resources/js/ssr.js`.