### PR TITLE
Add support for running inside a Sail container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,11 @@ export default function laravel(config?: string|string[]|Partial<PluginConfig>):
                 },
                 server: {
                     origin: '__laravel_vite_placeholder__',
+                    ...(process.env.LARAVEL_SAIL ? {
+                        host: '0.0.0.0',
+                        port: env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173,
+                        strictPort: true,
+                    } : undefined)
                 },
                 resolve: {
                     alias: Array.isArray(userConfig.resolve?.alias)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,6 +19,9 @@ describe('laravel-vite-plugin', () => {
 
         const serveConfig = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(serveConfig.base).toBe('')
+        expect(buildConfig.server.host).toBeUndefined()
+        expect(buildConfig.server.port).toBeUndefined()
+        expect(buildConfig.server.strictPort).toBeUndefined()
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/build/')
@@ -187,5 +190,31 @@ describe('laravel-vite-plugin', () => {
         }, { command: 'build', mode: 'development' })
 
         expect(config.resolve.alias).toContainEqual({ find: 'ziggy', replacement: 'vendor/tightenco/ziggy/dist/index.es.js' })
+    })
+
+    it('configures the Vite server when inside a Sail container', () => {
+        process.env.LARAVEL_SAIL = '1'
+        const plugin = laravel()
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        expect(config.server.host).toBe('0.0.0.0')
+        expect(config.server.port).toBe(5173)
+        expect(config.server.strictPort).toBe(true)
+
+        delete process.env.LARAVEL_SAIL
+    })
+
+    it('allows the Vite port to be configured when inside a Sail container', () => {
+        process.env.LARAVEL_SAIL = '1'
+        process.env.VITE_PORT = '1234'
+        const plugin = laravel()
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        expect(config.server.host).toBe('0.0.0.0')
+        expect(config.server.port).toBe(1234)
+        expect(config.server.strictPort).toBe(true)
+
+        delete process.env.LARAVEL_SAIL
+        delete process.env.VITE_PORT
     })
 })


### PR DESCRIPTION
When running inside a Docker container, the Vite server needs to listen on the container's external address rather than just its localhost address.

The port also needs to be forwarded on the host machine to the container. We can achieve this with the following port configuration in the `laravel.test` container in Sail:

```
- '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
```

The port specified here is the new default as of Vite 3 (currently unreleased). We can safely use it now because our plugin will also specify that port when running in Docker.