### PR TITLE
Move vite to dependencies

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,7 +9,7 @@
 First you will need to install [Vite](https://vitejs.dev/) and the [Laravel Vite Plugin](https://www.npmjs.com/package/laravel-vite-plugin) using your npm package manager of choice:
 
 ```shell
-npm install --save-dev vite laravel-vite-plugin
+npm install --save-dev laravel-vite-plugin
 ```
 
 You may also need to install additional Vite plugins for your project, such as the Vue or React plugins:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
         "lint": "eslint --ext .ts ./src ./tests",
         "test": "vitest run"
     },
+    "dependencies": {
+        "vite": "^2.9.6"
+    },
     "devDependencies": {
         "@types/node": "^17.0.31",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
@@ -34,7 +37,6 @@
         "eslint": "^8.14.0",
         "picocolors": "^1.0.0",
         "typescript": "^4.6.4",
-        "vite": "^2.9.6",
         "vitest": "^0.12.4"
     },
     "engines": {


### PR DESCRIPTION
Hi @jessarcher 

Lets move `vite` package to `dependencies`

* Force end users to use maintainer's defined version of `vite` :muscle:
* Just one package to install by end users :pinching_hand:

Laravel-Mix does not ask you to install `webpack` separately, right? :smirk:

#### Additional things to be done
* Specify the minimum node.js version required in docs
* Specify the minimum Laravel Framework version to use `@vite` blade directive

