### PR TITLE
Update resolvePageComponent helper to work with both glob and glogEager

### DIFF
--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,4 +1,4 @@
-export async function resolvePageComponent<T>(path: string, pages: Record<string, T | () => Promise<T>>) {
+export async function resolvePageComponent<T>(path: string, pages: Record<string, T | (() => Promise<T>)>) {
     const page = pages[path]
     if (typeof page === 'undefined') {
         throw new Error(`Page not found: ${path}`)

--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -4,5 +4,5 @@ export async function resolvePageComponent<T>(path: string, pages: Record<string
         throw new Error(`Page not found: ${path}`)
     }
 
-    return typeof page === 'function' ? await page() : page
+    return typeof page === 'function' ? await (page as () => Promise<T>)() : page
 }

--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,8 +1,9 @@
-export async function resolvePageComponent<T>(path: string, pages: Record<string, T | (() => Promise<T>)>) {
+export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>): Promise<T> {
     const page = pages[path]
+
     if (typeof page === 'undefined') {
         throw new Error(`Page not found: ${path}`)
     }
 
-    return typeof page === 'function' ? await (page as () => Promise<T>)() : page
+    return typeof page === 'function' ? page() : page
 }

--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,7 +1,8 @@
-export function resolvePageComponent<T>(path: string, pages: Record<string, () => Promise<T>>) {
-    if (typeof pages[path] === 'undefined') {
+export async function resolvePageComponent<T>(path: string, pages: Record<string, T | () => Promise<T>>) {
+    const page = pages[path]
+    if (typeof page === 'undefined') {
         throw new Error(`Page not found: ${path}`)
     }
 
-    return pages[path]()
+    return typeof page === 'function' ? await page() : page
 }

--- a/tests/__data__/dummy.ts
+++ b/tests/__data__/dummy.ts
@@ -1,0 +1,1 @@
+export default 'Dummy File'

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import laravel from '../src'
+import { resolvePageComponent } from '../src/inertia-helpers';
 
 describe('laravel-vite-plugin', () => {
     afterEach(() => {
@@ -216,5 +217,18 @@ describe('laravel-vite-plugin', () => {
         const stringNoExternalConfig = plugin.config({ ssr: { noExternal: 'foo' }, build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
         expect(stringNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
+    })
+})
+
+describe('inertia-helpers', () => {
+    const path = './__data__/dummy.ts'
+    it('pass glob value to resolvePageComponent', async () => {
+        const file = await resolvePageComponent<{ default: string }>(path, import.meta.glob('./__data__/*.ts'))
+        expect(file.default).toBe('Dummy File')
+    })
+
+    it('pass globEager value to resolvePageComponent', async () => {
+        const file = await resolvePageComponent<{ default: string }>(path, import.meta.globEager('./__data__/*.ts'))
+        expect(file.default).toBe('Dummy File')
     })
 })


### PR DESCRIPTION
This pull request updates the `resolvePageComponent` inertia helper to work with the object returned both by the glob and globEager imports.