### PR TITLE
Add a default CSS entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import { Plugin, loadEnv, UserConfig, ConfigEnv, Manifest, ResolvedConfig } from
 
 interface PluginConfig {
     /**
-     * The path or path of the entry points to compile.
+     * The path or paths of the entry points to compile.
      *
-     * @default 'resources/js/app.js'
+     * @default ['resources/css/app.css', 'resources/js/app.js']
      */
     input: string|string[]|undefined
 
@@ -223,7 +223,7 @@ function resolvePluginConfig(config?: string|string[]|Partial<PluginConfig>): Pl
     }
 
     return {
-        input: config.input ?? 'resources/js/app.js',
+        input: config.input ?? ['resources/css/app.css', 'resources/js/app.js'],
         publicDirectory: config.publicDirectory ?? 'public',
         buildDirectory: config.buildDirectory ?? 'build',
         ssr: config.ssr ?? 'resources/js/ssr.js',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -15,7 +15,7 @@ describe('laravel-vite-plugin', () => {
         expect(buildConfig.base).toBe('/build/')
         expect(buildConfig.build.manifest).toBe(true)
         expect(buildConfig.build.outDir).toBe('public/build')
-        expect(buildConfig.build.rollupOptions.input).toBe('resources/js/app.js')
+        expect(buildConfig.build.rollupOptions.input).toEqual(['resources/css/app.css', 'resources/js/app.js'])
 
         const serveConfig = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(serveConfig.base).toBe('')


### PR DESCRIPTION
To avoid a "flash of unstyled content" with server-rendered HTML (i.e. Blade), we need to have a separate CSS entry point rather than importing CSS via a JavaScript entry point.

This PR adds Laravel's default CSS entry point as a default for the plugin, as there is no harm in doing so for SPA applications as well.