### PR TITLE
Prevent SSR build from externalizing Inertia helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,9 @@ function resolveOutDir(config: Required<PluginConfig>, ssr: boolean): string|und
     return path.join(config.publicDirectory, config.buildDirectory)
 }
 
+/**
+ * Resolve the Vite manifest config from the configuration.
+ */
 function resolveManifestConfig(config: ResolvedConfig): string|false
 {
     const manifestConfig = config.build.ssr

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -218,4 +218,28 @@ describe('laravel-vite-plugin', () => {
         delete process.env.LARAVEL_SAIL
         delete process.env.VITE_PORT
     })
+
+    it('prevents the Inertia helpers from being externalized', () => {
+        /* eslint-disable @typescript-eslint/ban-ts-comment */
+        const plugin = laravel('resources/js/app.js')
+
+        const noSsrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
+        /* @ts-ignore */
+        expect(noSsrConfig.ssr.noExternal).toEqual(['laravel-vite-plugin'])
+
+        /* @ts-ignore */
+        const nothingExternalConfig = plugin.config({ ssr: { noExternal: true }, build: { ssr: true } }, { command: 'build', mode: 'production' })
+        /* @ts-ignore */
+        expect(nothingExternalConfig.ssr.noExternal).toBe(true)
+
+        /* @ts-ignore */
+        const arrayNoExternalConfig = plugin.config({ ssr: { noExternal: ['foo'] }, build: { ssr: true } }, { command: 'build', mode: 'production' })
+        /* @ts-ignore */
+        expect(arrayNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
+
+        /* @ts-ignore */
+        const stringNoExternalConfig = plugin.config({ ssr: { noExternal: 'foo' }, build: { ssr: true } }, { command: 'build', mode: 'production' })
+        /* @ts-ignore */
+        expect(stringNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
+    })
 })


### PR DESCRIPTION
This PR fixes an issue where Vite SSR builds would fail to run due to the ESM Inertia helpers being incorrectly detected as externalizable (I know, right...)

The [`ssr` options](https://vitejs.dev/config/#ssr-options) are experimental/alpha so they aren't included in the type definition, hence the ts-ignores.

https://vitejs.dev/guide/ssr.html#ssr-externals

Tested with Breeze and Jetstream.