### PR TITLE
Respect server.host variable in hot file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
                     const protocol = server.config.server.https ? 'https' : 'http'
-                    const configHost = typeof resolvedConfig.server.host === 'string' ? resolvedConfig.server.host : false
+                    const configHost = typeof server.config.server.host === 'string' ? server.config.server.host : false
                     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
                     const host = configHost || serverAddress
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,9 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
                     const protocol = server.config.server.https ? 'https' : 'http'
-                    const host = address.family === 'IPv6' ? `[${address.address}]` : address.address
+                    const configHost = typeof resolvedConfig.server.host === 'string' ? resolvedConfig.server.host : false
+                    const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
+                    const host = configHost || serverAddress
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,9 +120,9 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
                     const protocol = server.config.server.https ? 'https' : 'http'
-                    const configHost = typeof server.config.server.host === 'string' ? server.config.server.host : false
+                    const configHost = typeof server.config.server.host === 'string' ? server.config.server.host : null
                     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
-                    const host = configHost || serverAddress
+                    const host = configHost ?? serverAddress
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 


### PR DESCRIPTION
This PR adds support for Vite's `server.host` setting when writing the address to the hot file.

Fixes #23
