### PR TITLE
Respect envDir when resolving assetUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
         enforce: 'post',
         config: (userConfig, { command, mode }) => {
             const ssr = !! userConfig.build?.ssr
-            const env = loadEnv(mode, process.cwd(), '')
+            const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
             const assetUrl = env.ASSET_URL ?? ''
 
             return {


### PR DESCRIPTION
Line I missed when submitting #22.

This will use the custom envDir when resolving the assetUrl to be used as `base` when running a build.
