### PR TITLE
Allow server configuration to be overriden inside a Sail container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,9 +79,9 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                 server: {
                     origin: '__laravel_vite_placeholder__',
                     ...(process.env.LARAVEL_SAIL ? {
-                        host: '0.0.0.0',
-                        port: env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173,
-                        strictPort: true,
+                        host: userConfig.server?.host ?? '0.0.0.0',
+                        port: userConfig.server?.port ?? (env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173),
+                        strictPort: userConfig.server?.strictPort ?? true,
                     } : undefined)
                 },
                 resolve: {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -195,6 +195,24 @@ describe('laravel-vite-plugin', () => {
         delete process.env.VITE_PORT
     })
 
+    it('allows the server configuration to be overridden inside a Sail container', () => {
+        process.env.LARAVEL_SAIL = '1'
+        const plugin = laravel('resources/js/app.js')
+
+        const config = plugin.config({
+            server: {
+                host: 'example.com',
+                port: 1234,
+                strictPort: false,
+            }
+        }, { command: 'serve', mode: 'development' })
+        expect(config.server.host).toBe('example.com')
+        expect(config.server.port).toBe(1234)
+        expect(config.server.strictPort).toBe(false)
+
+        delete process.env.LARAVEL_SAIL
+    })
+
     it('prevents the Inertia helpers from being externalized', () => {
         /* eslint-disable @typescript-eslint/ban-ts-comment */
         const plugin = laravel('resources/js/app.js')


### PR DESCRIPTION
This PR helps to address #28.

It allows the user to override the Vite `server` configuration when running inside a Sail container.