### PR TITLE
[0.x] Ensure manifest always contains a file key for CSS sources

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
             cssManifest[relativeChunkPath] = {
                 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
                 /* @ts-ignore */
-                file: Array.from(chunk.viteMetadata.importedCss)[0],
+                file: Array.from(chunk.viteMetadata.importedCss)[0] ?? chunk.fileName,
                 src: relativeChunkPath,
                 isEntry: true,
             }


### PR DESCRIPTION
This PR fixes an issue when a CSS entry point is an empty file.

When this is the case, the manifest is missing the `file` key, which is used to generate the HTML script / link tags.

This fix ensures that there is always a file key present.

Fixes #33


This brings our Vite 2 workaround in alignment with how Vite 3 handles manifest generation for empty CSS files.