### PR TITLE
[0.x] Fix issue with manifest not existing when the legacy asset bundle occurs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,6 +184,12 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
             }
 
             const manifestPath = path.resolve(resolvedConfig.root, resolvedConfig.build.outDir, manifestConfig)
+
+            if (! fs.existsSync(manifestPath)) {
+                // The manifest does not exist yet when first writing the legacy asset bundle.
+                return;
+            }
+
             const manifest = JSON.parse(fs.readFileSync(manifestPath).toString())
             const newManifest = {
                 ...manifest,


### PR DESCRIPTION
Fixes #36

The `writeBundle()` hook gets called twice when using `@vitejs/plugin-legacy`. The first time is before the manifest has been generated by Vite.

I could not find a reasonable way to determine when writing the legacy bundle, so this change seems like the safest option.