### PR TITLE
Use HMR host when set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,9 +120,10 @@ export default function laravel(config: string|string[]|PluginConfig): LaravelPl
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
                     const protocol = server.config.server.https ? 'https' : 'http'
+                    const configHmrHost = typeof server.config.server.hmr === 'object' ? server.config.server.hmr.host : null
                     const configHost = typeof server.config.server.host === 'string' ? server.config.server.host : null
                     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
-                    const host = configHost ?? serverAddress
+                    const host = configHmrHost ?? configHost ?? serverAddress
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 


### PR DESCRIPTION
This PR updates the hot file generation to use Vite's [`server.hmr.host`](https://vitejs.dev/config/#server-hmr) config option when specified by the user.

This configuration option is intended to tell the Vite client where to find the HMR server for cases where it is different from [`server.host`](https://vitejs.dev/config/#server-host). I believe it makes sense for us to use it as well.

This probably helps a range of use cases, but specifically, it allows users to run Vite inside a Sail container that is running inside WSL, where the Vite dev server needs to be configured on the container's public address, but where the host machine cannot connect to this same address.

Closes #28