### PR TITLE
[0.3.0] Support full page reload on blade / arbitrary file changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     },
     "engines": {
         "node": ">=14"
+    },
+    "dependencies": {
+        "vite-plugin-full-reload": "^1.0.0"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,24 +50,28 @@ interface FullReloadConfig {
     config?: {
         /**
          * Whether full reload should happen regardless of the file path.
+         *
          * @default true
          */
         always?: boolean
 
         /**
          * How many milliseconds to wait before reloading the page after a file change.
+         *
          * @default 0
          */
         delay?: number
 
         /**
          * Whether to log when a file change triggers a full reload.
+         *
          * @default true
          */
         log?: boolean
 
         /**
          * Files will be resolved against this path.
+         *
          * @default process.cwd()
          */
         root?: string
@@ -138,10 +142,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                                 replacement: defaultAliases[alias]
                             }))
                         ]
-                            : {
-                                ...defaultAliases,
-                                ...userConfig.resolve?.alias,
-                            }
+                        : {
+                            ...defaultAliases,
+                            ...userConfig.resolve?.alias,
+                        }
                 },
                 ssr: {
                     noExternal: noExternalInertiaHelpers(userConfig),
@@ -169,7 +173,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
                     const host = configHost ?? serverAddress
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
-                        fs.writeFileSync(hotFile, viteDevServerUrl)
+                    fs.writeFileSync(hotFile, viteDevServerUrl)
 
                     const envDir = resolvedConfig.envDir || process.cwd()
                     const appUrl = loadEnv('', envDir, 'APP_URL').APP_URL

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ interface PluginConfig {
      *
      * @default false
      */
-    fullReload?: boolean|string|string[]|FullReloadConfig|FullReloadConfig[]
+    refresh?: boolean|string|string[]|FullReloadConfig|FullReloadConfig[]
 }
 
 interface FullReloadConfig {
@@ -294,8 +294,8 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         config.ssrOutputDirectory = config.ssrOutputDirectory.trim().replace(/^\/+/, '').replace(/\/+$/, '')
     }
 
-    if (config.fullReload === true) {
-        config.fullReload = [{ paths: ['resources/views/**', 'routes/**'] }]
+    if (config.refresh === true) {
+        config.refresh = [{ paths: ['resources/views/**', 'routes/**'] }]
     }
 
     return {
@@ -304,7 +304,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         buildDirectory: config.buildDirectory ?? 'build',
         ssr: config.ssr ?? config.input,
         ssrOutputDirectory: config.ssrOutputDirectory ?? 'storage/ssr',
-        fullReload: config.fullReload ?? false,
+        refresh: config.refresh ?? false,
     }
 }
 
@@ -357,7 +357,7 @@ function resolveManifestConfig(config: ResolvedConfig): string|false
     return manifestConfig
 }
 
-function resolveFullReloadConfig({ fullReload: config }: Required<PluginConfig>): PluginOption[]{
+function resolveFullReloadConfig({ refresh: config }: Required<PluginConfig>): PluginOption[]{
     if (typeof config === 'boolean') {
         return [];
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ interface PluginConfig {
     /**
      * Configuration for performing full page refresh on blade (or other) file changes.
      *
+     * {@link https://github.com/ElMassimo/vite-plugin-full-reload}
      * @default false
      */
     refresh?: boolean|string|string[]|FullReloadConfig|FullReloadConfig[]

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -243,7 +243,7 @@ describe('laravel-vite-plugin', () => {
         expect(plugins.length).toBe(1)
     })
 
-    it('does not configure full reload when fullReload is not present', () => {
+    it('does not configure full reload when refresh is not present', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
         })
@@ -251,27 +251,27 @@ describe('laravel-vite-plugin', () => {
         expect(plugins.length).toBe(1)
     })
 
-    it('does not configure full reload when fullReload is set to undefined', () => {
+    it('does not configure full reload when refresh is set to undefined', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: undefined,
+            refresh: undefined,
         })
         expect(plugins.length).toBe(1)
     })
 
-    it('does not configure full reload when fullReload is false', () => {
+    it('does not configure full reload when refresh is false', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: false,
+            refresh: false,
         })
 
         expect(plugins.length).toBe(1)
     })
 
-    it('configures full reload with routes and views when fullReload is true', () => {
+    it('configures full reload with routes and views when refresh is true', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: true,
+            refresh: true,
         })
 
         expect(plugins.length).toBe(2)
@@ -281,10 +281,10 @@ describe('laravel-vite-plugin', () => {
         })
     })
 
-    it('configures full reload whenFullReload is a single path', () => {
+    it('configures full reload when refresh is a single path', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: 'path/to/watch/**',
+            refresh: 'path/to/watch/**',
         })
 
         expect(plugins.length).toBe(2)
@@ -294,10 +294,10 @@ describe('laravel-vite-plugin', () => {
         })
     })
 
-    it('configures full reload when fullReload is an array of paths', () => {
+    it('configures full reload when refresh is an array of paths', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: ['path/to/watch/**', 'another/to/watch/**'],
+            refresh: ['path/to/watch/**', 'another/to/watch/**'],
         })
 
         expect(plugins.length).toBe(2)
@@ -307,10 +307,10 @@ describe('laravel-vite-plugin', () => {
         })
     })
 
-    it('configures full reload when fullReload is a complete configuration to proxy', () => {
+    it('configures full reload when refresh is a complete configuration to proxy', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: {
+            refresh: {
                 paths: ['path/to/watch/**', 'another/to/watch/**'],
                 config: { delay: 987 }
             },
@@ -324,10 +324,10 @@ describe('laravel-vite-plugin', () => {
         })
     })
 
-    it('configures full reload when fullReload is an array of complete configurations to proxy', () => {
+    it('configures full reload when refresh is an array of complete configurations to proxy', () => {
         const plugins = laravel({
             input: 'resources/js/app.js',
-            fullReload: [
+            refresh: [
                 {
                     paths: ['path/to/watch/**'],
                     config: { delay: 987 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -20,7 +20,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('accepts a single input', () => {
-        const plugin = laravel('resources/js/app.ts')
+        const plugin = laravel('resources/js/app.ts')[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
@@ -33,7 +33,7 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel([
             'resources/js/app.ts',
             'resources/js/other.js',
-        ])
+        ])[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
@@ -49,7 +49,7 @@ describe('laravel-vite-plugin', () => {
             buildDirectory: 'other-build',
             ssr: 'resources/js/ssr.ts',
             ssrOutputDirectory: 'other-ssr-output',
-        })
+        })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/other-build/')
@@ -68,7 +68,7 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel({
             input: 'resources/js/app.js',
             ssr: 'resources/js/ssr.js',
-        })
+        })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/build/')
@@ -85,7 +85,7 @@ describe('laravel-vite-plugin', () => {
 
     it('uses the default entry point when ssr entry point is not provided', () => {
         // This is support users who may want a dedicated Vite config for SSR.
-        const plugin = laravel('resources/js/ssr.js')
+        const plugin = laravel('resources/js/ssr.js')[0]
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
@@ -93,7 +93,7 @@ describe('laravel-vite-plugin', () => {
 
     it('prefixes the base with ASSET_URL in production mode', () => {
         process.env.ASSET_URL = 'http://example.com'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const devConfig = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(devConfig.base).toBe('')
@@ -105,12 +105,12 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('prevents setting an empty publicDirectory', () => {
-        expect(() => laravel({ input: 'resources/js/app.js', publicDirectory: '' }))
+        expect(() => laravel({ input: 'resources/js/app.js', publicDirectory: '' })[0])
             .toThrowError('publicDirectory must be a subdirectory');
     })
 
     it('prevents setting an empty buildDirectory', () => {
-        expect(() => laravel({ input: 'resources/js/app.js', buildDirectory: '' }))
+        expect(() => laravel({ input: 'resources/js/app.js', buildDirectory: '' })[0])
             .toThrowError('buildDirectory must be a subdirectory');
     })
 
@@ -120,7 +120,7 @@ describe('laravel-vite-plugin', () => {
             publicDirectory: '/public/test/',
             buildDirectory: '/build/test/',
             ssrOutputDirectory: '/ssr-output/test/',
-        })
+        })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/build/test/')
@@ -131,7 +131,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('provides an @ alias by default', () => {
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'development' })
 
@@ -139,7 +139,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('respects a users existing @ alias', () => {
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({
             resolve: {
@@ -153,7 +153,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('appends an Alias object when using an alias array', () => {
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({
             resolve: {
@@ -171,7 +171,7 @@ describe('laravel-vite-plugin', () => {
 
     it('configures the Vite server when inside a Sail container', () => {
         process.env.LARAVEL_SAIL = '1'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(config.server.host).toBe('0.0.0.0')
@@ -184,7 +184,7 @@ describe('laravel-vite-plugin', () => {
     it('allows the Vite port to be configured when inside a Sail container', () => {
         process.env.LARAVEL_SAIL = '1'
         process.env.VITE_PORT = '1234'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(config.server.host).toBe('0.0.0.0')
@@ -197,7 +197,7 @@ describe('laravel-vite-plugin', () => {
 
     it('allows the server configuration to be overridden inside a Sail container', () => {
         process.env.LARAVEL_SAIL = '1'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({
             server: {
@@ -215,7 +215,7 @@ describe('laravel-vite-plugin', () => {
 
     it('prevents the Inertia helpers from being externalized', () => {
         /* eslint-disable @typescript-eslint/ban-ts-comment */
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const noSsrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
@@ -235,6 +235,121 @@ describe('laravel-vite-plugin', () => {
         const stringNoExternalConfig = plugin.config({ ssr: { noExternal: 'foo' }, build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
         expect(stringNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
+    })
+
+    it('does not configure full reload when configuration it not an object', () => {
+        const plugins = laravel('resources/js/app.js')
+
+        expect(plugins.length).toBe(1)
+    })
+
+    it('does not configure full reload when fullReload is not present', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+        })
+
+        expect(plugins.length).toBe(1)
+    })
+
+    it('does not configure full reload when fullReload is set to undefined', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: undefined,
+        })
+        expect(plugins.length).toBe(1)
+    })
+
+    it('does not configure full reload when fullReload is false', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: false,
+        })
+
+        expect(plugins.length).toBe(1)
+    })
+
+    it('configures full reload with routes and views when fullReload is true', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: true,
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['resources/views/**', 'routes/**'],
+        })
+    })
+
+    it('configures full reload whenFullReload is a single path', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: 'path/to/watch/**',
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**'],
+        })
+    })
+
+    it('configures full reload when fullReload is an array of paths', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: ['path/to/watch/**', 'another/to/watch/**'],
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**', 'another/to/watch/**'],
+        })
+    })
+
+    it('configures full reload when fullReload is a complete configuration to proxy', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: {
+                paths: ['path/to/watch/**', 'another/to/watch/**'],
+                config: { delay: 987 }
+            },
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**', 'another/to/watch/**'],
+            config: { delay: 987 }
+        })
+    })
+
+    it('configures full reload when fullReload is an array of complete configurations to proxy', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: [
+                {
+                    paths: ['path/to/watch/**'],
+                    config: { delay: 987 }
+                },
+                {
+                    paths: ['another/to/watch/**'],
+                    config: { delay: 123 }
+                },
+            ],
+        })
+
+        expect(plugins.length).toBe(3)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**'],
+            config: { delay: 987 }
+        })
+        /** @ts-ignore */
+        expect(plugins[2].__laravel_plugin_config).toEqual({
+            paths: ['another/to/watch/**'],
+            config: { delay: 123 }
+        })
     })
 })
 


### PR DESCRIPTION
This PR introduces the ability to preform full page refreshes when specific files change.

This is extremely useful when changes are made to Blade files, routes, and other files that will impact the application.

This feature is built atop of the fantastic plugin that was created in the Ruby community: https://github.com/ElMassimo/vite-plugin-full-reload. This Plugin can of course be used directly, however we introduce some nice defaults and an escape hatch via the Laravel plugin.

## refresh: true

This option sets some sensible defaults for the plugin. It will listen for changes on...

```
routes/**
resources/views/**
```

Example config...

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js'
            ],
            refresh: true,
        }),
    ],
});
```

## refresh: string

This option allows you to specify a single path to watch.

Example config...

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js'
            ],
            refresh: 'resources/routes/**',
        }),
    ],
});
```

## refresh: string[]

This option allows you to specify a list of paths to watch.

Example config...

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js'
            ],
            refresh: ['resources/routes/**', 'routes/**'],
        }),
    ],
});
```

## refresh: FullRefreshConfig

This option allows you to specify a full config that is passed to the underlying plugin. See [their config references](https://github.com/ElMassimo/vite-plugin-full-reload#configuration-%EF%B8%8F) for more details...

Example config...

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js'
            ],
            refresh: { 
                paths: ['resources/routes/**', 'routes/**'],
                config: { delay: 300 },
            },
        }),
    ],
});
```

## refresh: FullRefreshConfig[]

This option allows you to specify an array of full configurations that are passed to the underlying plugin and create multiple instances. This is the same as specifying the plugin multiple times which you may want if you want a delay on refreshing some paths and not others because there is a 3rd party build process for certain paths...

Example config...

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js'
            ],
            refresh: [
                { 
                    paths: ['resources/routes/**'],
                },
                { 
                    paths: ['some/other/path**'],
                    config: { delay: 300 },
                },
            ],
        }),
    ],
});
```

## Questions to answer before merging

- Should we watch for configuration changes as well?
- Should we watch for `.env` changes?

## Notes

I'd like to ask the original plugin maintainer if they would export their interface so we don't have to recreate it here, but I won't do that unless we move ahead with this PR.