### PR TITLE
[0.3.x] Add `app/View/Components/**` to default refresh paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,9 @@ export default function laravel(config: string|string[]|PluginConfig): [LaravelP
     ];
 }
 
+/**
+ * Resolve the Laravel Plugin configuration.
+ */
 function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlugin {
     let viteDevServerUrl: string
     let resolvedConfig: ResolvedConfig

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,12 @@ interface LaravelPlugin extends Plugin {
 
 let exitHandlersBound = false
 
+export const refreshPaths = [
+    'app/View/Components/**',
+    'resources/views/**',
+    'routes/**',
+]
+
 /**
  * Laravel plugin for Vite.
  *
@@ -301,7 +307,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
     }
 
     if (config.refresh === true) {
-        config.refresh = [{ paths: ['resources/views/**', 'routes/**'] }]
+        config.refresh = [{ paths: refreshPaths }]
     }
 
     return {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -277,7 +277,7 @@ describe('laravel-vite-plugin', () => {
         expect(plugins.length).toBe(2)
         /** @ts-ignore */
         expect(plugins[1].__laravel_plugin_config).toEqual({
-            paths: ['resources/views/**', 'routes/**'],
+            paths: ['app/View/Components/**', 'resources/views/**', 'routes/**'],
         })
     })
 


### PR DESCRIPTION
This PR adds `app/View/Components/**` to the global default directories to watch and perform full page reloads for. This is useful as View Components may be entirely specified in the class itself with no blade file.

Additionally, it also exports the default directories so users can utilise the default list and just add their own. Here would be an example of he export usage...

```js
import { defineConfig } from 'vite';
import laravel, { refreshPaths } from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js',
            ],
            refresh: [
                ...refreshPaths,
                'app/Http/Livewire/**'
            ],
        }),
    ],
});

```