### PR TITLE
Account for an hmr protocol different than the vite server's protocol

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,11 +169,16 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
-                    const protocol = server.config.server.https ? 'https' : 'http'
+                    const configHmrProtocol = typeof server.config.server.hmr === 'object' ? server.config.server.hmr.protocol : null
+                    const clientHmrProtocol = configHmrProtocol ? (configHmrProtocol === 'wss' ? 'https' : 'http') : null
+                    const configProtocol = server.config.server.https ? 'https' : 'http'
+                    const protocol = clientHmrProtocol ?? configProtocol
+
                     const configHmrHost = typeof server.config.server.hmr === 'object' ? server.config.server.hmr.host : null
                     const configHost = typeof server.config.server.host === 'string' ? server.config.server.host : null
                     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
                     const host = configHmrHost ?? configHost ?? serverAddress
+
                     viteDevServerUrl = `${protocol}://${host}:${address.port}`
                     fs.writeFileSync(hotFile, viteDevServerUrl)
 


### PR DESCRIPTION
Currently, the protocol used for the URL presented to the client (for connecting to Vite dev server) is based on the `server.https` config of the dev server.

`const protocol = server.config.server.https ? 'https' : 'http'`

It is reasonable that a user would want the Vite dev server to run without SSL, but have the client connect using SSL. I use a reverse proxy container in my docker environment which routes traffic to the Laravel Sail containers for a couple different projects. The reverse proxy is responsible for terminating the SSL connection and it in turn communicates with the service container over HTTP.

In this environment, the Vite dev server is running and listening for HTTP from within the Laravel Sail container, but the client needs to communicate with the reverse proxy over HTTPS. 

`server.hmr.protocol` is pre-existing but is not considered by `laravel/vite-plugin` when building the URL for the client connection.

My approach piggy-backs on @jessarcher's PR #42 where the `server.hmr.host` config is allowed to override `server.host`

This PR is backwards compatible as omitting `server.hmr.protocol` will render a client URL using `server.https` to determine the protocol, as was being done before.

I ran the test suite before adding a test for this, but there are no current tests for the `viteDevServerUrl` variable and I could not figure out how to make assertions against its value.

I'm more than happy to provide a test if someone could help with a way to assert against the value of `viteDevServerUrl`

Please ask any questions about this, I can also provide additional environment details with the reverse proxy if that would help!
