### PR TITLE
Use HMR port when specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -400,8 +400,10 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig): DevS
     const configHost = typeof config.server.host === 'string' ? config.server.host : null
     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
     const host = configHmrHost ?? configHost ?? serverAddress
+    
+    const port = typeof config.server.hmr === 'object' ? (config.server.hmr.port ?? address.port)
 
-    return `${protocol}://${host}:${address.port}`
+    return `${protocol}://${host}:${port}`
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,7 +402,7 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig): DevS
     const host = configHmrHost ?? configHost ?? serverAddress
     
     const configHmrClientPort = typeof config.server.hmr === 'object' ? config.server.hmr.clientPort : null
-    const port = configHmrPort ?? address.port
+    const port = configHmrClientPort ?? address.port
 
     return `${protocol}://${host}:${port}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,7 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig): DevS
     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
     const host = configHmrHost ?? configHost ?? serverAddress
     
-    const port = typeof config.server.hmr === 'object' ? (config.server.hmr.port ?? address.port)
+    const port = typeof config.server.hmr === 'object' ? config.server.hmr.port : address.port
 
     return `${protocol}://${host}:${port}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,8 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig): DevS
     const serverAddress = address.family === 'IPv6' ? `[${address.address}]` : address.address
     const host = configHmrHost ?? configHost ?? serverAddress
     
-    const port = typeof config.server.hmr === 'object' ? config.server.hmr.port : address.port
+    const configHmrClientPort = typeof config.server.hmr === 'object' ? config.server.hmr.clientPort : null
+    const port = configHmrPort ?? address.port
 
     return `${protocol}://${host}:${port}`
 }


### PR DESCRIPTION
This PR updates the hot file generation to use Vite's [`server.hmr.port`](https://vitejs.dev/config/#server-hmr) config option when specified by the user.

This configuration option is intended to tell the Vite client where to find the HMR server port for cases where it is different from [`server.port`](https://vitejs.dev/config/#server-port). I believe it makes sense for us to use it as well.

This probably helps a range of use cases, but specifically, it allows users to run Vite inside a Sail container that is running inside WSL, where the Vite dev server needs to be configured on the container's public address, but where the host machine cannot connect to this same address.

Users running Vite inside Sail inside WSL will need to add the following to the `defineConfig` section of their `vite.config.js` file:

```
server: {
    hmr: {
        port: 3001,
    },
},
```