### PR TITLE
[0.4] Change default SSR build directory

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -319,13 +319,13 @@ You may wish to add the following additional scripts to your `package.json`:
 If you prefer to build your assets on deploy instead of committing them to your repository, you may wish to add the SSR output directory to your `.gitignore` file:
 
 ```gitignore
-/storage/ssr
+/bootstrap/ssr
 ```
 
 You may start the SSR server using `node`:
 
 ```sh
-node storage/ssr/ssr.js
+node bootstrap/ssr/ssr.js
 ```
 
 ### Wrapping up
@@ -479,6 +479,6 @@ rm vite.config.js
 You may also wish to remove any `.gitignore` paths you are no longer using:
 
 ```gitignore
+- /bootstrap/ssr
 - /public/build
-- /storage/ssr
 ```

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "build-plugin": "rm -rf dist && tsc && cp src/dev-server-index.html dist/",
         "build-inertia-helpers": "rm -rf inertia-helpers && tsc --project tsconfig.inertia-helpers.json",
         "lint": "eslint --ext .ts ./src ./tests",
-        "ssr:serve": "vite build --ssr && node storage/ssr/ssr.js",
         "test": "vitest run"
     },
     "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ interface PluginConfig {
     /**
      * The directory where the SSR bundle should be written.
      *
-     * @default 'storage/ssr'
+     * @default 'bootstrap/ssr'
      */
     ssrOutputDirectory?: string
 
@@ -305,7 +305,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         publicDirectory: config.publicDirectory ?? 'public',
         buildDirectory: config.buildDirectory ?? 'build',
         ssr: config.ssr ?? config.input,
-        ssrOutputDirectory: config.ssrOutputDirectory ?? 'storage/ssr',
+        ssrOutputDirectory: config.ssrOutputDirectory ?? 'bootstrap/ssr',
         refresh: config.refresh ?? false,
     }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -79,7 +79,7 @@ describe('laravel-vite-plugin', () => {
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/build/')
         expect(ssrConfig.build.manifest).toBe(false)
-        expect(ssrConfig.build.outDir).toBe('storage/ssr')
+        expect(ssrConfig.build.outDir).toBe('bootstrap/ssr')
         expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
     })
 


### PR DESCRIPTION
This PR changes the default SSR build output directory from `storage/ssr` to `bootstrap/ssr`.

As pointed out in https://github.com/laravel/docs/pull/8024, Envoyer symlinks the `storage` directory to preserve it between deploys. This means that anything placed in the `storage` directory on build won't be available after deploying.

**Background**

Prior to Vite, a common location was `public/js/ssr.js`, however, Vite outputs everything to a single "build" directory (`public/build` in Laravel), so `public/js`, etc. are no longer used. We can't share the same directory for the SSR and non-SSR builds as Vite wipes the directory on build.

When considering a new directory, we decided against the `public` directory because the SSR server is not downloaded by clients, and it's potentially a security issue making it public.

The storage directory was originally chosen because this is a common place for Laravel to write application files. The mistake was that this directory is typically only written to at _runtime_, rather than at _build_ time.

With `storage` and `public` out, we're not left with many options. The `resources` directory doesn't feel right because this typically contains source files, not compiled assets. The `bootstrap` directory seems like a good fit, as this is where Laravel already places files on build (caches, etc). We could also go with a new root-level directory, but I think `bootstrap` makes a lot of sense.

**Note this is a breaking change!** It will also require updates to the `.gitignore` file in `laravel/laravel`.