### PR TITLE
Add note for people using Laravel Sail to get local dev environment working with Vite.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -330,21 +330,19 @@ node storage/ssr/ssr.js
 
 ### Optional: Update default HMR port when using Laravel Sail
 
-If you are using Laravel Sail, you must update the `HMR_PORT` in your `.env` file.
-
-```diff
-- HMR_PORT=8080
-+ HMR_PORT=5173
-```
-
-Alternatively, you can set the default value in your `docker-compose.yml` file.
-
+If you are using Laravel Sail, you need to update the default `HMR_PORT` value and the port it maps to in your `docker-compose.yml` file.
 
 ```diff
 - -'${HMR_PORT:-8080}:8080'
 + -'${HMR_PORT:-5173}:5173'
 ```
 
+If you are setting the HMR_PORT in your `.env` file you will also need to update it to match.
+
+```diff
+- HMR_PORT=8080
++ HMR_PORT=5173
+```
 
 ### Wrapping up
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -328,20 +328,12 @@ You may start the SSR server using `node`:
 node storage/ssr/ssr.js
 ```
 
-### Optional: Update default HMR port when using Laravel Sail
+### Optional: Expose Vite port when using Laravel Sail
 
-If you are using Laravel Sail, you need to update the default `HMR_PORT` value and the port it maps to in your `docker-compose.yml` file.
-
-```diff
-- -'${HMR_PORT:-8080}:8080'
-+ -'${HMR_PORT:-5173}:5173'
-```
-
-If you are setting the HMR_PORT in your `.env` file you will also need to update it to match.
+If you are using Laravel Sail, you need to add a binding in your `docker-compose.yml` file for your `VITE_PORT`.
 
 ```diff
-- HMR_PORT=8080
-+ HMR_PORT=5173
++ -'${VITE_PORT:-5173}:5173'
 ```
 
 ### Wrapping up

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -333,7 +333,9 @@ node storage/ssr/ssr.js
 If you are using Laravel Sail, you need to add a binding in your `docker-compose.yml` file for your `VITE_PORT`.
 
 ```diff
-+ -'${VITE_PORT:-5173}:5173'
+ports:
+    - '${APP_PORT:-80}:80'
++   - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
 ```
 
 ### Wrapping up

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -330,7 +330,7 @@ node storage/ssr/ssr.js
 
 ### Optional: Expose Vite port when using Laravel Sail
 
-If you are using Laravel Sail, you need to add a binding in your `docker-compose.yml` file for your `VITE_PORT`.
+If you would like to run the `npm run dev` command in a Laravel Sail container, you will need to publish a port in your `docker-compose.yml` file:
 
 ```diff
 ports:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -328,6 +328,24 @@ You may start the SSR server using `node`:
 node storage/ssr/ssr.js
 ```
 
+### Optional: Update default HMR port when using Laravel Sail
+
+If you are using Laravel Sail, you must update the `HMR_PORT` in your `.env` file.
+
+```diff
+- HMR_PORT=8080
++ HMR_PORT=5173
+```
+
+Alternatively, you can set the default value in your `docker-compose.yml` file.
+
+
+```diff
+- -'${HMR_PORT:-8080}:8080'
++ -'${HMR_PORT:-5173}:5173'
+```
+
+
 ### Wrapping up
 
 You should now be able to build your assets using `dev` command. This will also invoke the Vite server and Vite will watch for file changes:


### PR DESCRIPTION
I recently followed the migration guide to migrate from Laravel mix to Vite. I completed all the steps and ran `sail npm run dev`. Unfortunately, it did not work for me, all I could see was a blank screen and some errors in the browser console. This was because I was using Laravel sail for local development. The issue was pretty simple and I thought it would be worth mentioning in the Upgrade guide.

Vite uses a different port (5173) for HMR compared to Laravel mix (8080), and since the default HMR port in Laravel sail is set to 8080, local development does not work without changing the port mapping in your `docker-compose.yml`.
