### PR TITLE
Update upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,7 @@ composer require laravel/framework:^9.19.0
 First, you will need to install [Vite](https://vitejs.dev/) and the [Laravel Vite Plugin](https://www.npmjs.com/package/laravel-vite-plugin) using your npm package manager of choice:
 
 ```shell
-npm install --save-dev vite laravel-vite-plugin
+npm install --save-dev vite@^2.9 laravel-vite-plugin
 ```
 
 You may also need to install additional Vite plugins for your project, such as the Vue or React plugins:


### PR DESCRIPTION
Vite 3.x breaks npm peer dependencies. Use explicit `vite@^2.9` to resolve properly until package.json is updated for Vite 3

```bash
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: undefined@undefined
npm ERR! Found: vite@3.0.1
npm ERR! node_modules/vite
npm ERR!   dev vite@"^3.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer vite@"^2.9.9" from laravel-vite-plugin@0.4.0
npm ERR! node_modules/laravel-vite-plugin
npm ERR!   dev laravel-vite-plugin@"^0.4.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/garrick/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/garrick/.npm/_logs/2022-07-18T13_42_56_345Z-debug-0.log
```

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
