### PR TITLE
Do not externalise inertia helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,7 +360,7 @@ function noExternalInertiaHelpers(config: UserConfig): true|Array<string|RegExp>
     /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
     /* @ts-ignore */
     const userNoExternal = (config.ssr as SSROptions|undefined)?.noExternal
-    const pluginNoExternal = ['laravel-vite-plugin/inertia-helpers']
+    const pluginNoExternal = ['laravel-vite-plugin']
 
     if (userNoExternal === true) {
         return true

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -219,7 +219,7 @@ describe('laravel-vite-plugin', () => {
 
         const noSsrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
-        expect(noSsrConfig.ssr.noExternal).toEqual(['laravel-vite-plugin/inertia-helpers'])
+        expect(noSsrConfig.ssr.noExternal).toEqual(['laravel-vite-plugin'])
 
         /* @ts-ignore */
         const nothingExternalConfig = plugin.config({ ssr: { noExternal: true }, build: { ssr: true } }, { command: 'build', mode: 'production' })
@@ -229,12 +229,12 @@ describe('laravel-vite-plugin', () => {
         /* @ts-ignore */
         const arrayNoExternalConfig = plugin.config({ ssr: { noExternal: ['foo'] }, build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
-        expect(arrayNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin/inertia-helpers'])
+        expect(arrayNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
 
         /* @ts-ignore */
         const stringNoExternalConfig = plugin.config({ ssr: { noExternal: 'foo' }, build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
-        expect(stringNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin/inertia-helpers'])
+        expect(stringNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
     })
 
     it('does not configure full reload when configuration it not an object', () => {


### PR DESCRIPTION
Due to a [bugfix](https://github.com/vitejs/vite/pull/9146) in version Vite 3.0.1 we now need to revert to referencing the package by name directly in order to have Vite not externalise the helpers.

Fixes: #93

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
