### PR TITLE
Prevent console warning when Vite pings HMR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,12 +184,6 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
             return () => server.middlewares.use((req, res, next) => {
                 if (req.url === '/index.html') {
-                    server.config.logger.warn(
-                        "\n" + colors.bgYellow(
-                            colors.black(`The Vite server should not be accessed directly. Your Laravel application's configured APP_URL is: ${appUrl}`)
-                        )
-                    )
-
                     res.statusCode = 404
 
                     res.end(


### PR DESCRIPTION
This PR removes the console warning when the dev server is accessed directly.

This addresses an issue with Vite 3 where it now pings the root URL when it loses connection with the HMR server, showing this misleading error message.

It's tricky to distinguish between a user visit and a ping, because they're both made by the browser. While we could do it, potentially with some upstream help, I don't know that it's worth the effort as the index page we serve should hopefully be enough to guide users towards accessing a Laravel dev server.

Fixes #96 