### PR TITLE
Allow chosing different env files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,6 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const assetUrl = env.ASSET_URL ?? ''
 
             return {
-                mode: mode,
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
                 publicDir: false,
                 build: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const assetUrl = env.ASSET_URL ?? ''
 
             return {
+                mode: mode,
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
                 publicDir: false,
                 build: {
@@ -147,7 +148,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const hotFile = path.join(pluginConfig.publicDirectory, 'hot')
 
             const envDir = resolvedConfig.envDir || process.cwd()
-            const appUrl = loadEnv('', envDir, 'APP_URL').APP_URL
+            const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL
 
             server.httpServer?.once('listening', () => {
                 const address = server.httpServer?.address()
@@ -341,7 +342,7 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig): DevS
     const configHost = typeof config.server.host === 'string' ? config.server.host : null
     const serverAddress = isIpv6(address) ? `[${address.address}]` : address.address
     const host = configHmrHost ?? configHost ?? serverAddress
-    
+
     const configHmrClientPort = typeof config.server.hmr === 'object' ? config.server.hmr.clientPort : null
     const port = configHmrClientPort ?? address.port
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const hotFile = path.join(pluginConfig.publicDirectory, 'hot')
 
             const envDir = resolvedConfig.envDir || process.cwd()
-            const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL
+            const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL ?? 'undefined'
 
             server.httpServer?.once('listening', () => {
                 const address = server.httpServer?.address()


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello, 

I have a project in which i need to work with several env files, and none of them are simply called `.env`. 

I usually chose my env file using the `mode` option of vite.

But, when you run a vite server using `mode` option on an existing env file without a default `.env` file the server crash with this error: 

```
/var/www/Boreal/Upcover/Instances/Upcovel/node_modules/laravel-vite-plugin/dist/index.js:110
                        server.config.logger.info(`  ${picocolors_1.default.green('➜')}  ${picocolors_1.default.bold('APP_URL')}: ${picocolors_1.default.cyan(appUrl.replace(/:(\d+)/, (_, port) => `:${picocolors_1.default.bold(port)}`))}`);
                                                                                                                                                                     ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Timeout._onTimeout (/var/www/Boreal/Upcover/Instances/Upcovel/node_modules/laravel-vite-plugin/dist/index.js:110:166)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7)
```

In fact, in the `configureServer` method the env file loaded is the `.env` file, and it cannot be changed: 

```
const appUrl = loadEnv('', envDir, 'APP_URL').APP_URL
```

I suggest to change this line to:

```
const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL
```

And thus, add:

```
mode: mode,
```

In the config definition, it fixes the issue.

