### PR TITLE
Prevent trailing whitespace

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,4 +6,7 @@ module.exports = {
     parser: "@typescript-eslint/parser",
     plugins: ["@typescript-eslint"],
     extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+    rules: {
+        "no-trailing-spaces": "error",
+    },
 };


### PR DESCRIPTION
A recent PR introduced some trailing whitespace which wasn't obvious when reviewing. I'm not sure why this rule isn't enabled by default in the "recommend" rule set, so this PR enables it.