### PR TITLE
[0.5.x] Support customising hot file / build path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ interface PluginConfig {
 
     /**
      * The path to the "hot" file.
+     *
+     * @default `${publicDirectory}/hot`
      */
     hotFile?: string
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,11 @@ interface PluginConfig {
     buildDirectory?: string
 
     /**
+     * The path to the "hot" file.
+     */
+    hotFile?: string
+
+    /**
      * The path of the SSR entry point.
      */
     ssr?: string|string[]
@@ -144,8 +149,6 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             }
         },
         configureServer(server) {
-            const hotFile = path.join(pluginConfig.publicDirectory, 'hot')
-
             const envDir = resolvedConfig.envDir || process.cwd()
             const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL ?? 'undefined'
 
@@ -155,7 +158,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
                     viteDevServerUrl = resolveDevServerUrl(address, server.config)
-                    fs.writeFileSync(hotFile, viteDevServerUrl)
+                    fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
 
                     setTimeout(() => {
                         server.config.logger.info(`\n  ${colors.red(`${colors.bold('LARAVEL')} ${laravelVersion()}`)}  ${colors.dim('plugin')} ${colors.bold(`v${pluginVersion()}`)}`)
@@ -170,8 +173,8 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             }
 
             const clean = () => {
-                if (fs.existsSync(hotFile)) {
-                    fs.rmSync(hotFile)
+                if (fs.existsSync(pluginConfig.hotFile)) {
+                    fs.rmSync(pluginConfig.hotFile)
                 }
             }
 
@@ -268,6 +271,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         ssr: config.ssr ?? config.input,
         ssrOutputDirectory: config.ssrOutputDirectory ?? 'bootstrap/ssr',
         refresh: config.refresh ?? false,
+        hotFile: config.hotFile ?? path.join((config.publicDirectory ?? 'public'), 'hot')
     }
 }
 


### PR DESCRIPTION
This PR introduces a new configuration option to specify the location of the hot file. This is really just an escape hatch from our normal conventions.

```js
// vite.config.js

export default defineConfig({
    plugins: [
        laravel({
            hotFile: 'storage/vite.hot',
            // ...
        }),
    ],
});
```

```blade
// *.blade.php

{{ Vite::useHotFile(storage_path('vite.hot'))->withEntryPoints(['resources/js/app.js']) }}
```

This PR depends on: https://github.com/laravel/framework/pull/43620

The ability to customise the build directory (as seen in the above linked PR) is already possible without the need for additional changes to the plugin:

```js
// vite.config.js

export default defineConfig({
    plugins: [
        laravel({
            buildDirectory: 'foo/bar',
            // ...
        }),
    ],
});
```


```blade
// *.blade.php

{{ Vite::useBuildDirectory('foo/bar')->withEntryPoints(['resources/js/app.js']) }}
```

Note that by design the build directory is always relative to the public directory but the hot path is used as is.