### PR TITLE
[0.6.x] Fail running HMR in known environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+env:
+  LARAVEL_BYPASS_ENV_CHECK: 1
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,10 @@ function ensureCommandShouldRunInEnvironment(command: 'build'|'serve', env: Reco
         throw Error('You should not run the Vite HMR server in your Forge deployment script. You should build your assets for production instead.');
     }
 
+    if (typeof env.LARAVEL_ENVOYER !== 'undefined') {
+        throw Error('You should not run the Vite HMR server in your Envoyer hook. You should build your assets for production instead.');
+    }
+
     if (typeof env.CI !== 'undefined') {
         throw Error('You should not run the Vite HMR server in CI environments. You should build your assets for production instead.');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
  * Validate the command can run in the given environment.
  */
 function validateCommandOnEnvironment(command: 'build'|'serve', env: Record<string, string>): void {
-    if (command === 'build') {
+    if (command === 'build' || env.LARAVEL_BYPASS_ENV_CHECK === '1') {
         return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
             const assetUrl = env.ASSET_URL ?? ''
 
-            validateCommandOnEnvironment(command, env)
+            ensureCommandShouldRunInEnvironment(command, env)
 
             return {
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
@@ -202,21 +202,21 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 /**
  * Validate the command can run in the given environment.
  */
-function validateCommandOnEnvironment(command: 'build'|'serve', env: Record<string, string>): void {
+function ensureCommandShouldRunInEnvironment(command: 'build'|'serve', env: Record<string, string>): void {
     if (command === 'build' || env.LARAVEL_BYPASS_ENV_CHECK === '1') {
         return;
     }
 
     if (typeof env.VAPOR_SSM_PATH !== 'undefined') {
-        throw Error('You should not run the Vite HMR server (`npm run dev`) on Vapor. Instead you should run `npm run build`.');
+        throw Error('You should not run the Vite HMR server on Vapor. You should build your assets for production instead.');
     }
 
     if (typeof env.LARAVEL_FORGE !== 'undefined') {
-        throw Error('You should not run the Vite HMR server (`npm run dev`) in your Forge deployment script. Instead you should run `npm run build`.');
+        throw Error('You should not run the Vite HMR server in your Forge deployment script. You should build your assets for production instead.');
     }
 
     if (typeof env.CI !== 'undefined') {
-        throw Error('You should not run the Vite HMR server (`npm run dev`) in CI. Instead you should run `npm run build`.');
+        throw Error('You should not run the Vite HMR server in CI environments. You should build your assets for production instead.');
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,8 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
             const assetUrl = env.ASSET_URL ?? ''
 
+            validateCommandOnEnvironment(command, env)
+
             return {
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
                 publicDir: false,
@@ -194,6 +196,27 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 next()
             })
         }
+    }
+}
+
+/**
+ * Validate the command can run in the given environment.
+ */
+function validateCommandOnEnvironment(command: 'build'|'serve', env: Record<string, string>): void {
+    if (command === 'build') {
+        return;
+    }
+
+    if (typeof env.VAPOR_SSM_PATH !== 'undefined') {
+        throw Error('You should not run the Vite HMR server (`npm run dev`) on Vapor. Instead you should run `npm run build`.');
+    }
+
+    if (typeof env.FORGE_PHP !== 'undefined') {
+        throw Error('You should not run the Vite HMR server (`npm run dev`) in your Forge deployment script. Instead you should run `npm run build`.');
+    }
+
+    if (typeof env.CI !== 'undefined') {
+        throw Error('You should not run the Vite HMR server (`npm run dev`) in CI. Instead you should run `npm run build`.');
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,7 @@ function ensureCommandShouldRunInEnvironment(command: 'build'|'serve', env: Reco
         return;
     }
 
-    if (typeof env.VAPOR_SSM_PATH !== 'undefined') {
+    if (typeof env.LARAVEL_VAPOR !== 'undefined') {
         throw Error('You should not run the Vite HMR server on Vapor. You should build your assets for production instead.');
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,7 @@ function validateCommandOnEnvironment(command: 'build'|'serve', env: Record<stri
         throw Error('You should not run the Vite HMR server (`npm run dev`) on Vapor. Instead you should run `npm run build`.');
     }
 
-    if (typeof env.FORGE_PHP !== 'undefined') {
+    if (typeof env.LARAVEL_FORGE !== 'undefined') {
         throw Error('You should not run the Vite HMR server (`npm run dev`) in your Forge deployment script. Instead you should run `npm run build`.');
     }
 


### PR DESCRIPTION
This PR introduces some nice errors for developers when running the HMR server (`npm run dev`) in known environments where it shouldn't be run, specifically:

- Forge
- Vapor
- Envoyer (see: https://github.com/laravel/envoyer/pull/156)
- Misc Continuous Integration

The ENV check can be overridden:

```sh
LARAVEL_BYPASS_ENV_CHECK=1 npm run dev
```