### PR TITLE
[0.6.x] Add config option to utilise Valet TLS certificates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -429,7 +429,7 @@ function resolveValetServerConfig(host: string|boolean): {
     const certPath = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.crt`)
 
     if (! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
-        throw Error('Unable to find Valet certificate files. Ensure you have run `valet secure`.')
+        throw Error(`Unable to find Valet certificate files for your host [${host}]. Ensure you have run "valet secure".`)
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,9 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const ssr = !! userConfig.build?.ssr
             const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
             const assetUrl = env.ASSET_URL ?? ''
-            const valetServerConfig = resolveValetServerConfig(pluginConfig.valetTls)
+            const valetServerConfig = command === 'serve'
+                ? resolveValetServerConfig(pluginConfig.valetTls)
+                : undefined
 
             return {
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,10 +425,10 @@ function resolveValetServerConfig(host: string|boolean): {
 
     host = host === true ? resolveValetHost() : host
 
-    const key = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.key`)
-    const cert = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.crt`)
+    const keyPath = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.key`)
+    const certPath = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.crt`)
 
-    if (! fs.existsSync(key) || ! fs.existsSync(cert)) {
+    if (! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
         throw Error('Unable to find Valet certificate files. Ensure you have run `valet secure`.')
     }
 
@@ -436,8 +436,8 @@ function resolveValetServerConfig(host: string|boolean): {
         hmr: { host },
         host,
         https: {
-            key: fs.readFileSync(key),
-            cert: fs.readFileSync(cert),
+            key: fs.readFileSync(keyPath),
+            cert: fs.readFileSync(certPath),
         },
     }
 }


### PR DESCRIPTION
This PR introduces a new `valetTls` configuration option to allow developers to use Valet generated certificates on their Mac. This is useful as Vite 3 no longer generates a self signed certificate. Valet also puts certificates into the system keychain, so if you are using Chromium or Safari the experience is seamless. 

Unfortunately Firefox does not seem to read from the system keychain, so you may still need to additionally accept the Valet certificate for the Vite server, as we currently have to.

When setting the configuration option to `true`, the plugin will automatically detect the host by checking the current directory name and appending the configured Valet TLD:

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            valetTls: true,
        }),
    ],
});
```

If you have linked you site via a different host, that is if you are in the `my-app` directory and ran:

```
valet link my-host
valet secure my-host
```

so that you can view "my-app" by visiting https://my-host.test, then you should specify the host along with the TLD in the `valetTls` option:

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            valetTls: 'my-host.test',
        }),
    ],
});
```

User config will always take precedence over the underlying generated Valet config.


Documentation PR: https://github.com/laravel/docs/pull/8164