### PR TITLE
[0.6.x] Do not inline small assets, by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     rollupOptions: {
                         input: userConfig.build?.rollupOptions?.input ?? resolveInput(pluginConfig, ssr)
                     },
+                    assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },
                 server: {
                     origin: '__laravel_vite_placeholder__',


### PR DESCRIPTION
By default Vite will "inline" assets that are smaller than 4kb by base64 encoding them.

From a Laravel perspective this can cause issues for Blade apps that are looking to use the `Vite::asset()` helper on small assets.

Blade specific apps could set this to `0` manually, however I also find the inconsistent behaviour as the _default_ strange - even if it is beneficial to SPA style applications. I feel setting this to `0` is a good default for Laravel, while still respecting the user configured value.

The alternative would be to add some magic into the `asset` helper, but I don't think we can generally assume the file will still be in it's pre-bundled location (e.g. resources/images/pixel.png) as apps may clear that stuff out for space reasons (e.g. Serverless).

Encoding at runtime also kinda sucks as well - and the inconsistency in the returned result is a little weird (plain URL vs base64 url).

I think if this is something the community wants we could add an additional function `assetOrEncoded()` or something along those lines. But I think we can punt that down the road for now.