### PR TITLE
[0.7.x] Add `lang` directories to default refresh paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,8 @@ let exitHandlersBound = false
 export const refreshPaths = [
     'app/View/Components/**',
     'resources/views/**',
+    'resources/lang/**',
+    'lang/**',
     'routes/**',
 ]
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -277,7 +277,7 @@ describe('laravel-vite-plugin', () => {
         expect(plugins.length).toBe(2)
         /** @ts-ignore */
         expect(plugins[1].__laravel_plugin_config).toEqual({
-            paths: ['app/View/Components/**', 'resources/views/**', 'routes/**'],
+            paths: ['app/View/Components/**', 'resources/views/**', 'resources/lang/**', 'lang/**', 'routes/**'],
         })
     })
 


### PR DESCRIPTION
This PR adds `lang/**` and `resources/lang/**` to the global default directories to watch in order to perform full reloads when translation are updated