### PR TITLE
[0.6.x] Ensure custom 404 page shows after server restarts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,22 +170,20 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 }
             })
 
-            if (exitHandlersBound) {
-                return
-            }
-
-            const clean = () => {
-                if (fs.existsSync(pluginConfig.hotFile)) {
-                    fs.rmSync(pluginConfig.hotFile)
+            if (! exitHandlersBound) {
+                const clean = () => {
+                    if (fs.existsSync(pluginConfig.hotFile)) {
+                        fs.rmSync(pluginConfig.hotFile)
+                    }
                 }
+
+                process.on('exit', clean)
+                process.on('SIGINT', process.exit)
+                process.on('SIGTERM', process.exit)
+                process.on('SIGHUP', process.exit)
+
+                exitHandlersBound = true
             }
-
-            process.on('exit', clean)
-            process.on('SIGINT', process.exit)
-            process.on('SIGTERM', process.exit)
-            process.on('SIGHUP', process.exit)
-
-            exitHandlersBound = true
 
             return () => server.middlewares.use((req, res, next) => {
                 if (req.url === '/index.html') {


### PR DESCRIPTION
fixes: #140

Currently the custom 404 page stops displaying if the server has restarted. This fixes that issue.