### PR TITLE
[0.7] Respect user manifest config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
                 publicDir: false,
                 build: {
-                    manifest: !ssr,
+                    manifest: userConfig.build?.manifest ?? !ssr,
                     outDir: userConfig.build?.outDir ?? resolveOutDir(pluginConfig, ssr),
                     rollupOptions: {
                         input: userConfig.build?.rollupOptions?.input ?? resolveInput(pluginConfig, ssr)


### PR DESCRIPTION
This PR addresses https://github.com/laravel/vite-plugin/issues/149 by respecting the users' `build.manifest` configuration if provided.

I've conservatively marked this as 0.7 because it could change the behaviour if a user had specified a manifest config, which would previously have been ignored.