### PR TITLE
[0.6.x] Support loading certificates from environment variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -452,13 +452,13 @@ function resolveEnvironmentServerConfig(env: Record<string, string>): {
     }
 
     if (! fs.existsSync(env.VITE_DEV_SERVER_KEY) || ! fs.existsSync(env.VITE_DEV_SERVER_CERT)) {
-        throw Error(`Unable to find the certificate files specified in your environment. Ensure you have correctly configured VITE_DEV_SERVER_KEY: [${env.VITE_DEV_SERVER_KEY}] and VITE_DEV_SERVER_KEY: [${env.VITE_DEV_SERVER_CERT}].`)
+        throw Error(`Unable to find the certificate files specified in your environment. Ensure you have correctly configured VITE_DEV_SERVER_KEY: [${env.VITE_DEV_SERVER_KEY}] and VITE_DEV_SERVER_CERT: [${env.VITE_DEV_SERVER_CERT}].`)
     }
 
     const host = resolveHostFromEnv(env)
 
     if (! host) {
-        throw Error(`Unable to determine the host from the APP_URL: [${env.APP_URL}].`)
+        throw Error(`Unable to determine the host from the environment's APP_URL: [${env.APP_URL}].`)
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,23 +443,23 @@ function noExternalInertiaHelpers(config: UserConfig): true|Array<string|RegExp>
 /**
  * Resolve the server config from the environment.
  */
-function resolveServerConfig(env: Record<string, string>) {
-	const host = resolveHostFromEnv(env)
-  const keyPath = env.VITE_DEV_SERVER_KEY
-  const certPath = env.VITE_DEV_SERVER_CERT
+function resolveEnvironmentServerConfig(env: Record<string, string>) {
+    const host = resolveHostFromEnv(env)
+    const keyPath = env.VITE_DEV_SERVER_KEY
+    const certPath = env.VITE_DEV_SERVER_CERT
 
-  if (!host || ! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
-      return
-  }
+    if (! host || ! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
+        return
+    }
 
-	return {
-		hmr: { host },
-		host,
-		https: {
-				key: fs.readFileSync(keyPath),
-				cert: fs.readFileSync(certPath),
-		},
-}
+    return {
+        hmr: { host },
+        host,
+        https: {
+            key: fs.readFileSync(keyPath),
+            cert: fs.readFileSync(certPath),
+        },
+    }
 }
 
 /**
@@ -467,11 +467,11 @@ function resolveServerConfig(env: Record<string, string>) {
  */
 function resolveHostFromEnv(env: Record<string, string>): string|undefined
 {
-	try {
-		return new URL(env.APP_URL).host
-	} catch {
-		return
-	}
+    try {
+        return new URL(env.APP_URL).host
+    } catch {
+        return
+    }
 }
 
 


### PR DESCRIPTION
This PR adds support for loading certificates thanks to paths defined in the environment. 

Currently, in our team, we use `valetTls`, which is very nice for us Valet users. But a member of our team uses Windows and Laragon, and cannot benefit from the configuration. 

With this PR, they will be able to define `VITE_DEV_SERVER_KEY` and `VITE_DEV_SERVER_CERT` in their `.env` with the paths to their Laragon certificates. That way, there is no need to touch `vite.config.ts`, so it can keep being environment-agnostic.

~~Keeping this as a draft to test it on my own Windows machine later~~ - also, not so sure about the variable names: `VITE_*` environment variables are available in the front-end through `import.meta.env`.