### PR TITLE
Move picocolors from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint": "^8.14.0",
-        "picocolors": "^1.0.0",
         "typescript": "^4.6.4",
         "vite": "^3.0.0",
         "vitest": "^0.12.4"
@@ -44,6 +43,7 @@
         "node": ">=14"
     },
     "dependencies": {
+        "picocolors": "^1.0.0",
         "vite-plugin-full-reload": "^1.0.1"
     }
 }


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Trying to use this with the latest Yarn version, using the default setup (including Yarn PnP for installations), trying to use Laravel + Vite results in an error:
```
Error: laravel-vite-plugin tried to access picocolors, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

Reproduction:
- Clone the latst Laravel skeleton (https://github.com/laravel/laravel)
- Setup the latest yarn version for the project with `yarn set version stable`
- Install node modules with `yarn install`
- Run `yarn dev`

To prevent dependency clashes, Yarn requires any package to explicitly list all packages it uses in its dependencies. Currently, this package does not list `picocolors` as explicit dependency, but obtains it as indirect dependency through `vite-plugin-full-reload`.

This MR marks `picocolors` as explicit dependency to prevent this error from occuring.

*Note:* For a workaround, this dependency can be manually added to your yarn configuration, see https://github.com/jnoordsij/laravel/commit/ca9da91696c82d32cb85a80dacbef30426e23ccc.