### PR TITLE
[0.8.x] Change certificate resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,7 @@ function resolveValetServerConfig(env: Record<string, string>): {
     host?: string,
     https?: { cert: Buffer, key: Buffer }
 }|undefined {
-		const host = resolveHostFromEnv(env)
+    const host = resolveHostFromEnv(env)
     const keyPath = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.key`)
     const certPath = path.resolve(os.homedir(), `.config/valet/Certificates/${host}.crt`)
 


### PR DESCRIPTION
Closes #162

This pull request changes how the certificates for the development server are resolved. 

Previously, the `valetTls` option needed to be defined for Valet certificates to be inferred. However, this is not an environment-agnostic solution: if a developer works on Windows, they will get an error when the server starts.

I tried to mitigate this through https://github.com/laravel/vite-plugin/pull/151, but this requires `valetTls` to be removed/set to `false`, and everyone to specify their certificates in their `.env`, which is super inconvenient.

Even when using `valetTls`, the current implementation tries to find certificates by using the current working directory's name instead of the `APP_URL`, which is problematic when the directory name is not the same as the `APP_URL`. This can be fixed by setting `valetTls` to the name of the domain, but then this breaks the configuration for the rest of the team — so we're back to setting `valetTls` to `false` and manually specifying the certificates in the `.env`.

To fix all of these issues:
- The `valetTls` option in `vite.config.ts` should be removed
- Certificates should be inferred in a logical order (environment-defined certificates first, then Valet certificates)
- Certificate resolution should not throw an error

~~Marking this as draft to properly test it in all of our environments.~~