### PR TITLE
[0.7.x] Fix node type issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
         "test": "vitest run"
     },
     "devDependencies": {
-        "@types/node": "^17.0.31",
+        "@types/node": "^18.11.9",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint": "^8.14.0",
         "picocolors": "^1.0.0",
         "typescript": "^4.6.4",
         "vite": "^3.0.0",
-        "vitest": "^0.12.4"
+        "vitest": "^0.25.2"
     },
     "peerDependencies": {
         "vite": "^3.0.0"


### PR DESCRIPTION
Fixes this issue we have with the build by upgrading the version of typescript we are using.

Upgraded `vitetest` while I was in there.

<img width="2172" alt="Screen Shot 2022-11-18 at 10 01 19 am" src="https://user-images.githubusercontent.com/24803032/202578375-b128203c-ab0c-442f-86d7-5d9f63b2932a.png">
