### PR TITLE
Serve assets from the public directory during dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
             return {
                 base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
-                publicDir: false,
+                publicDir: command === 'build' ? false : pluginConfig.publicDirectory,
                 build: {
                     manifest: userConfig.build?.manifest ?? !ssr,
                     outDir: userConfig.build?.outDir ?? resolveOutDir(pluginConfig, ssr),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -213,6 +213,20 @@ describe('laravel-vite-plugin', () => {
         delete process.env.LARAVEL_SAIL
     })
 
+    it('serves assets from the public directory during dev', () => {
+        const plugin = laravel('resources/js/app.js')[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        expect(config.publicDir).toBe('public')
+    })
+
+    it('does not copy the public directory to the outDir on build', () => {
+        const plugin = laravel('resources/js/app.js')[0]
+
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(config.publicDir).toBe(false)
+    })
+
     it('prevents the Inertia helpers from being externalized', () => {
         /* eslint-disable @typescript-eslint/ban-ts-comment */
         const plugin = laravel('resources/js/app.js')[0]


### PR DESCRIPTION
This PR addresses an issue during dev mode when referencing absolute paths in CSS when not importing the CSS via JS (e.g. when using Blade).

In this scenario, the CSS file is loaded directly from the Vite dev server (e.g. `http://127.0.0.1:5173/resources/js/app.css`) rather than it being injected into the head of the page being served by Laravel (e.g. `http://127.0.0.1:8000`).

Any absolute paths in the CSS are fetched from the host and port serving the CSS (e.g. `http://127.0.0.1:5173/images/taylor.jpg`) which the Vite dev server currently can't resolve.

This PR addresses this by setting Vite's [`publicDir`](https://vitejs.dev/config/shared-options.html#publicdir) config to the public directory *during dev mode only* so that it may resolve and serve the assets.

Importantly, the setting is left `false` during build because Vite's default behaviour is to copy everything from this directory into the `outDir`, which in our case is a child of the public directory.

This is not an issue when in build mode because the CSS is served by the same web server as the rest of the application.

Fixes #171