### PR TITLE
Respect user config for all config options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,8 +121,8 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             ensureCommandShouldRunInEnvironment(command, env)
 
             return {
-                base: command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
-                publicDir: false,
+                base: userConfig.base ?? command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
+                publicDir: userConfig.publicDir ?? false,
                 build: {
                     manifest: userConfig.build?.manifest ?? !ssr,
                     outDir: userConfig.build?.outDir ?? resolveOutDir(pluginConfig, ssr),
@@ -132,7 +132,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },
                 server: {
-                    origin: '__laravel_vite_placeholder__',
+                    origin: userConfig.server?.origin ?? '__laravel_vite_placeholder__',
                     ...(process.env.LARAVEL_SAIL ? {
                         host: userConfig.server?.host ?? '0.0.0.0',
                         port: userConfig.server?.port ?? (env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173),


### PR DESCRIPTION
This PR makes the plugin respect the user config for all remaining options.

It also represents a shift in my mindset for the plugin.

The intention was, and still is, to automatically configure Vite in a way that makes sense for a Laravel project because by default Vite is configured for a standalone JavaScript application.

However, there are some Vite config options that we believed _only_ made sense to be configured in a certain way with Laravel and so we effectively enforced them by always specifying our own value in place of anything from the user config. The thought was that if they don't like how the plugin configures Vite then they don't have to use it. The reality is that this plugin has extra functionality (like creating the hot file) that is a pain to re-implement just to tweak one option.

Over time we've incrementally supported individual options as people have made their case for them, and we now have only three remaining options that aren't customisable.

This change in mindset occurred when seeing a developer trying to solve an issue by customising one of these remaining options without realising that this plugin made their change ineffectual.

I still believe that developers should generally stick with the defaults, but with this change, we're no longer enforcing it.