### PR TITLE
[1.x] Auto detect Valet / Herd TLS certificates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -544,11 +544,15 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
     const certPath = path.resolve(configPath, 'Certificates', `${resolvedHost}.crt`)
 
     if (! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
-        if (host !== null) {
-            throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI or run \`valet secure\`.`)
+        if (host === null) {
+            return
         }
 
-        return
+        if (configPath === herdConfigPath()) {
+            throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI.`)
+        } else {
+            throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site by running \`valet secure\`.`)
+        }
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -550,6 +550,8 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
 
         if (configPath === herdConfigPath()) {
             throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI.`)
+        } else if (typeof host === 'string') {
+            throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site by running \`valet secure ${host}\`.`)
         } else {
             throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site by running \`valet secure\`.`)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -532,9 +532,7 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
         return
     }
 
-    // The logic here is not right. Check tests locally when this directory exists.
-
-    if (typeof configPath === 'undefined' && host !== null) {
+    if (typeof configPath === 'undefined') {
         throw Error(`Unable to find the Herd or Valet configuration directory. Please check they are correctly installed.`)
     }
 
@@ -546,9 +544,11 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
     const certPath = path.resolve(configPath, 'Certificates', `${resolvedHost}.crt`)
 
     if (! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
-        console.log(host)
-        console.log(configPath)
-        throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI or run \`valet secure\`.`)
+        if (host !== null) {
+            throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI or run \`valet secure\`.`)
+        }
+
+        return
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ interface PluginConfig {
     /**
      * Utilise the Herd or Valet TLS certificates.
      *
-     * @default false
+     * @default null
      * @deprecated use "detectTls" instead
      */
     valetTls?: string|boolean|null,
@@ -532,7 +532,9 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
         return
     }
 
-    if (typeof configPath === 'undefined') {
+    // The logic here is not right. Check tests locally when this directory exists.
+
+    if (typeof configPath === 'undefined' && host !== null) {
         throw Error(`Unable to find the Herd or Valet configuration directory. Please check they are correctly installed.`)
     }
 
@@ -544,6 +546,8 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
     const certPath = path.resolve(configPath, 'Certificates', `${resolvedHost}.crt`)
 
     if (! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
+        console.log(host)
+        console.log(configPath)
         throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI or run \`valet secure\`.`)
     }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -199,7 +199,6 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
-        console.log(config)
         expect(config.server.host).toBe('0.0.0.0')
         expect(config.server.port).toBe(1234)
         expect(config.server.strictPort).toBe(true)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -199,6 +199,7 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        console.log(config)
         expect(config.server.host).toBe('0.0.0.0')
         expect(config.server.port).toBe(1234)
         expect(config.server.strictPort).toBe(true)


### PR DESCRIPTION
This PR adds:

- Valet / Herd certificate auto-detection (✨) and makes it the default for upcoming `1.x` release.
- Ability to opt-out of auto-detection `detectTls: false`.
- CLI output to indicate when the Valet / Herd certificate is being used (when known).

Assume everywhere "Valet" is mentioned that it also applies to "Herd".

This PR allows teams with a mixture of Valet and non-Valet users to configure TLS certificates, without adding additional configuration.

The following standard Laravel plugin config supports both use-cases:

```js
import fs from 'fs'
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            refresh: true,
        }),
    ],
});
```

For Valet users, as long as a Valet certificate is found it will be used. Valet certificates are "guessed" in the same way they currently are.

1. $CWD is used as the host.
2. TLD is resolved from the Valet config.

For non-Valet users, you may specify the path to TLS certificates with the existing environment options.

```sh
VITE_DEV_SERVER_KEY=/path/to/key
VITE_DEV_SERVER_CERT=/path/to/cert
```

## CLI output

We now output on the CLI when Vite certificates are in use. This will help users know when the Valet certificates have been auto-detected, etc.

<img width="492" alt="Screen Shot 2022-12-09 at 12 30 28 pm" src="https://user-images.githubusercontent.com/24803032/206602593-16499650-1e30-4c41-a5a6-ad22dd2771f0.png">

The `valetTls` option now has the following options.

```js
laravel({
  // ...

  // Auto-detection.
  // - Host is guessed via convention.
  // - Missing certificates are ignored.
  // _

  // Explicitly use Valet certificates.
  // - Host is guessed via convention.
  // - Errors are thrown when missing certificates. 
  valetTls: true,

  // Explicitly use Valet certificates.
  // - Host specified is used.
  // - Errors are thrown when missing certificates. 
  valetTls: 'tim.dev',

  // Opt-out of auto-detection.
  valetTls: false,
}),
```