### PR TITLE
Update release docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,8 @@
 Releases are managed by [@taylorotwell](https://github.com/taylorotwell), [@jessarcher](https://github.com/jessarcher), and [@timacdonald](https://github.com/timacdonald) for this repository.
 
 1. Update the version number in [package.json](./package.json) and commit it
-2. `npm install`
-3. `npm run build`
-4. `npm publish`
-5. Create a new GitHub release for this version with the release notes
+2. `rm -rf node_modules package-lock.json`
+3. `npm install`
+4. `npm run build`
+5. `npm publish`
+6. Create a new GitHub release for this version with the release notes


### PR DESCRIPTION
This PR updates `RELEASE.md` to avoid an issue where the plugin could be built without the latest dependencies.

We don't commit the `package-lock.json` to this repository, so it's necessary to at least run `npm update` instead of an `npm install`. I figured it's probably safer to just start from a clean slate rather than updating, though.