### PR TITLE
[0.7.x] Prevent Vite from injecting duplicate modulepreload tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                         input: userConfig.build?.rollupOptions?.input ?? resolveInput(pluginConfig, ssr)
                     },
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
+                    modulePreload: userConfig.build?.modulePreload ?? false,
                 },
                 server: {
                     origin: userConfig.server?.origin ?? '__laravel_vite_placeholder__',


### PR DESCRIPTION
The `@vite` directive in Laravel outputs `modulepreload` tags as of https://github.com/laravel/framework/pull/44096.

Vite itself also injects `modulepreload` tags into the `<head>` of the page via the JavaScript entrypoint, resulting in duplicates.

This PR aims to solve this by disabling the Vite feature in favour of the tags being injected by Laravel, which can include them in the initial HTML rather than having to wait until the entrypoint has been downloaded.