### PR TITLE
[0.7.x] Update package.json to use vite 4 compatible vite-plugin-full-reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     },
     "dependencies": {
         "picocolors": "^1.0.0",
-        "vite-plugin-full-reload": "^1.0.1"
+        "vite-plugin-full-reload": "^1.0.5"
     }
 }


### PR DESCRIPTION
Update dependency `vite-plugin-full-reload` to use `v1.0.5` so `warning "laravel-vite-plugin > vite-plugin-full-reload@1.0.4" has incorrect peer dependency "vite@^2 || ^3".` warning can be fixed.

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
