### PR TITLE
[0.7.x] Respects users base config option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             ensureCommandShouldRunInEnvironment(command, env)
 
             return {
-                base: userConfig.base ?? command === 'build' ? resolveBase(pluginConfig, assetUrl) : '',
+                base: userConfig.base ?? (command === 'build' ? resolveBase(pluginConfig, assetUrl) : ''),
                 publicDir: userConfig.publicDir ?? false,
                 build: {
                     manifest: userConfig.build?.manifest ?? !ssr,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -64,6 +64,18 @@ describe('laravel-vite-plugin', () => {
         expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.ts')
     })
 
+    it('respects users base config option', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+        })[0]
+
+        const userConfig = { base: '/foo/' }
+
+        const config = plugin.config(userConfig, { command: 'build', mode: 'production' })
+
+        expect(config.base).toBe('/foo/')
+    })
+
     it('accepts a partial configuration', () => {
         const plugin = laravel({
             input: 'resources/js/app.js',


### PR DESCRIPTION
Due to a precedence issue with `??` and `?:`, the user's `base` option is not currently being respected. This PR fixes that to ensure that the users config always takes precedence.

Fixes #185 
