### PR TITLE
[0.7.x] Build MJS and CJS versions of the plugin

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -102,6 +102,12 @@ Update your NPM scripts in `package.json`:
   }
 ```
 
+You should also add `"type": "module"` as a top-level key / value pair to your project's `package.json` by running the following command:
+
+```shell
+npm pkg set type="module"
+```
+
 ### Vite compatible imports
 
 Vite only supports ES modules, so if you are upgrading an existing application you will need to replace any `require()` statements with `import`. You may refer to [this pull request](https://github.com/laravel/laravel/pull/5895/files) for an example.
@@ -265,7 +271,37 @@ Then you will need to specify the base URL for assets in your application's entr
 
 ### Optional: Configure Tailwind
 
-If you are using Tailwind, perhaps with one of Laravel's starter kits, you will need to create a `postcss.config.js` file. Tailwind can generate this for you automatically:
+If you are using Tailwind, perhaps with one of Laravel's starter kits, you will need migrate your `tailwind.config.js` to use [Vite compatible imports](#vite-compatible-imports) and exports.
+
+```diff
+- const defaultTheme = require('tailwindcss/defaultTheme');
++ import defaultTheme from 'tailwindcss/defaultTheme';
++ import forms from '@tailwindcss/forms';
+
+/** @type {import('tailwindcss').Config} */
+- module.exports = {
++ export default {
+    content: [
+        './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
+        './storage/framework/views/*.php',
+        './resources/views/**/*.blade.php',
+        './resources/js/**/*.vue',
+    ],
+
+    theme: {
+        extend: {
+            fontFamily: {
+                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+            },
+        },
+    },
+
+-    plugins: [require('@tailwindcss/forms')],
++    plugins: [forms],
+};
+```
+
+You will also need to create a `postcss.config.cjs` file. Tailwind can generate this for you automatically:
 
 ```shell
 npx tailwindcss init -p
@@ -274,7 +310,7 @@ npx tailwindcss init -p
 Or, you can create it manually:
 
 ```js
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/package.json
+++ b/package.json
@@ -14,15 +14,27 @@
     },
     "license": "MIT",
     "author": "Laravel",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs",
+            "types": "./dist/index.d.ts"
+        },
+        "./inertia-helpers": {
+            "import": "./inertia-helpers/index.js",
+            "types": "./inertia-helpers/index.d.ts"
+        }
+    },
     "files": [
         "/dist",
         "/inertia-helpers"
     ],
     "scripts": {
         "build": "npm run build-plugin && npm run build-inertia-helpers",
-        "build-plugin": "rm -rf dist && tsc && cp src/dev-server-index.html dist/",
+        "build-plugin": "rm -rf dist && npm run build-plugin-types && npm run build-plugin-esm && npm run build-plugin-cjs && cp src/dev-server-index.html dist/",
+        "build-plugin-types": "tsc --emitDeclarationOnly",
+        "build-plugin-cjs": "esbuild src/index.ts --platform=node --format=cjs --outfile=dist/index.cjs",
+        "build-plugin-esm": "esbuild src/index.ts --platform=node --format=esm --outfile=dist/index.mjs",
         "build-inertia-helpers": "rm -rf inertia-helpers && tsc --project tsconfig.inertia-helpers.json",
         "lint": "eslint --ext .ts ./src ./tests",
         "test": "vitest run"
@@ -31,6 +43,7 @@
         "@types/node": "^18.11.9",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
+        "esbuild": "0.16.10",
         "eslint": "^8.14.0",
         "typescript": "^4.6.4",
         "vite": "^4.0.0",

--- a/tsconfig.inertia-helpers.json
+++ b/tsconfig.inertia-helpers.json
@@ -1,9 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "outDir": "inertia-helpers",
-        "target": "ES2020",
-        "module": "ES2020",
+        "outDir": "inertia-helpers"
     },
     "include": [
         "./src/inertia-helpers/index.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "outDir": "./dist",
-        "target": "ES2019",
-        "module": "commonjs",
+        "target": "ES2020",
+        "module": "ES2020",
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "strict": true,


### PR DESCRIPTION
> tl;dr; This PR brings support for projects using `"type": "modules"` to the Laravel plugin.

## Background

In there beginning, of this story at least, there were "CJS" or Common JS modules. CJS was the module system that Node created. It uses `require()` and `modules.export`.

Life was good in Node-land and the developers rejoiced in the streets.

Browsers did not support this standard.

ECMAScript then standardised ES Modules "MJS". This module system uses `import X from './foo'` and `export { X } ` type syntax.

Unfortunately for package maintainers there was now a need to compile both CJS and MJS builds. Some build tools or systems required CJS, while others required MJS.

These were the darkest of days.

After a good while, the ecosystem caught up. MJS and CJS was available for most relevant packages. The developers, once again, rejoiced in the streets - although the package maintainers lost sleep trying to work out how to even build two outputs and why this noise even exists. Here is, the one and only, "Wes Bos" with more...

<img width="598" alt="Screen Shot 2023-05-03 at 10 58 54 am" src="https://user-images.githubusercontent.com/24803032/235815348-d50b7d77-cf75-4f1f-87e9-e4ec7f1038b6.png">

Anyone who has done this can _feel_ the _pain_ emanating from this tweet.

Slowly though, the tide has shifted. Many mainstream packages are now dropping support for CJS and it seems this is the direction the ecosystem is heading. Again, Wes Bos with more...

<img width="595" alt="Screen Shot 2023-05-03 at 11 00 59 am" src="https://user-images.githubusercontent.com/24803032/235815490-aee913ed-0e07-4c7e-97e5-1e24efcae030.png">

MJS is now supported by browsers, which is how Vite works. I don't believe browsers _natively_ support MJS at all.

I don't think Node yet officially supports MJS. I believe there is experimental support for it.

**The facts may vary, but this is the general gist of things.

## Why

With a fresh install of Laravel, some major **Vite plugins** no longer work out of the box. The Svelte plugin, for example, no longer supports projects without `"type": "module"`. `"type": "module"` tells build tools, such as Vite, that you want to use ESM.

See: https://github.com/laravel/vite-plugin/issues/187

With Laravel's switch to Vite, all project level dependencies, that is dependencies that you use in your application code, already need to be MJS. Vite only works with projects using MJS. However, *Vite plugins* referenced in the `vite.config.js` file may be CJS or MJS.

This PR introduces an MJS version of the plugin so that we can make the `package.json` file use `"type": "module"` by default. 

This PR is only additive. It does not remove the CJS build. This means projects without `"type": "module"` will continue to build, as we continue to ship CJS.

See:

- https://github.com/laravel/laravel/pull/6090
- https://github.com/laravel/breeze/pull/246
- https://github.com/laravel/jetstream/pull/1242