### PR TITLE
[0.7.x] Update laravel doc link

### DIFF
--- a/src/dev-server-index.html
+++ b/src/dev-server-index.html
@@ -48,7 +48,7 @@
                         <div class="py-8 text-base leading-7">
                             <p>This is the Vite development server that provides Hot Module Replacement for your Laravel application.</p>
                             <p class="mt-6">To access your Laravel application, you will need to run a local development server.</p>
-                            <h2 class="mt-6"><a href="https://laravel.com/docs/9.x/installation#your-first-laravel-project" class="font-semibold text-red-500 hover:text-red-600">Artisan Serve</a></h2>
+                            <h2 class="mt-6"><a href="https://laravel.com/docs/installation#your-first-laravel-project" class="font-semibold text-red-500 hover:text-red-600">Artisan Serve</a></h2>
                             <p>Laravel's local development server powered by PHP's built-in web server.</p>
                             <h2 class="mt-6"><a href="https://laravel.com/docs/sail" class="font-semibold text-red-500 hover:text-red-600">Laravel Sail</a></h2>
                             <p>A light-weight command-line interface for interacting with Laravel's default Docker development environment.</p>


### PR DESCRIPTION
This PR update the laravel doc link so that it automatically jump to the latest doc.