### PR TITLE
[0.7.x] Polyfill import.meta.url for CJS builds

### DIFF
--- a/import.meta.url-polyfill.js
+++ b/import.meta.url-polyfill.js
@@ -1,0 +1,3 @@
+export const import_meta_url = typeof document === 'undefined'
+    ? new (require('url'.replace('', '')).URL)('file:' + __filename).href
+    : (document.currentScript && document.currentScript.src || new URL('main.js', document.baseURI).href)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "build": "npm run build-plugin && npm run build-inertia-helpers",
         "build-plugin": "rm -rf dist && npm run build-plugin-types && npm run build-plugin-esm && npm run build-plugin-cjs && cp src/dev-server-index.html dist/",
         "build-plugin-types": "tsc --emitDeclarationOnly",
-        "build-plugin-cjs": "esbuild src/index.ts --platform=node --format=cjs --outfile=dist/index.cjs",
+        "build-plugin-cjs": "esbuild src/index.ts --platform=node --format=cjs --outfile=dist/index.cjs --define:import.meta.url=import_meta_url --inject:./import.meta.url-polyfill.js",
         "build-plugin-esm": "esbuild src/index.ts --platform=node --format=esm --outfile=dist/index.mjs",
         "build-inertia-helpers": "rm -rf inertia-helpers && tsc --project tsconfig.inertia-helpers.json",
         "lint": "eslint --ext .ts ./src ./tests",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import { AddressInfo } from 'net'
 import os from 'os'
+import { fileURLToPath } from 'url'
 import path from 'path'
 import colors from 'picocolors'
 import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption } from 'vite'
@@ -224,7 +225,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     res.statusCode = 404
 
                     res.end(
-                        fs.readFileSync(path.join(__dirname, 'dev-server-index.html')).toString().replace(/{{ APP_URL }}/g, appUrl)
+                        fs.readFileSync(path.join(dirname(), 'dev-server-index.html')).toString().replace(/{{ APP_URL }}/g, appUrl)
                     )
                 }
 
@@ -277,7 +278,7 @@ function laravelVersion(): string {
  */
 function pluginVersion(): string {
     try {
-        return JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')).toString())?.version
+        return JSON.parse(fs.readFileSync(path.join(dirname(), '../package.json')).toString())?.version
     } catch {
         return ''
     }
@@ -536,4 +537,11 @@ function resolveValetHost(): string {
     const config: { tld: string } = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
 
     return path.basename(process.cwd()) + '.' + config.tld
+}
+
+/**
+ * The directory of the current file.
+ */
+function dirname(): string {
+    return fileURLToPath(new URL('.', import.meta.url))
 }


### PR DESCRIPTION
`__dirname` is not supported in ES Modules. This PR migrates to using `import.meta.url` and polyfiling the CJS build with the more modern approach.

Read more about ES Modules and `__dirname` here: https://blog.logrocket.com/alternatives-dirname-node-js-es-modules/

The polyfill was taken from: https://github.com/evanw/esbuild/issues/1633