### PR TITLE
[0.7.x] Expose base types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
             "types": "./inertia-helpers/index.d.ts"
         }
     },
+    "types": "./dist/index.d.ts",
     "files": [
         "/dist",
         "/inertia-helpers"


### PR DESCRIPTION
In order to support a TypeScript Vite config file, i.e., `vite.config.ts`, we still need to specify the older type style in the `package.json`. This was dropped when we migrated to modules but turns out for the plugin side of things it is still useful to expose them.

Laravel and none of the starter kits ship with with a TS Vite config, but it would still be nice to support it.