### PR TITLE
[0.7.x] Add providers to default refresh paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ type DevServerUrl = `${'http'|'https'}://${string}:${number}`
 let exitHandlersBound = false
 
 export const refreshPaths = [
+    'app/Providers/**',
     'app/View/Components/**',
     'resources/views/**',
     'resources/lang/**',


### PR DESCRIPTION
Providers often contain some configuration which affect the UI as well.
Adding them to the default refresh paths makes for a smoother developer experience.