### PR TITLE
[0.7.x] Ensure 'node' has a fallback type when working with static import linters

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         },
         "./inertia-helpers": {
             "import": "./inertia-helpers/index.js",
-            "types": "./inertia-helpers/index.d.ts"
+            "types": "./inertia-helpers/index.d.ts",
+            "node": "./inertia-helpers/index.js"
         }
     },
     "files": [


### PR DESCRIPTION
Fixes https://github.com/laravel/vite-plugin/issues/224

When using linters that are parsing and analysing imports from `package.json` files within the `node_modules` directory, they may fail because the `./inertia-helpers` do not, and never have, ship a CJS version.

Because the tooling is using CJS, it cannot find an appropriate import to use and Node itself fails.

This PR adds a fallback entrypoint for `node`. The entry point, as per the docs, may be CJS or MJS, thus we may just point to out existing MJS built assets.

You can read more about entry points in the node docs: https://nodejs.org/docs/latest-v16.x/api/packages.html#package-entry-points