### PR TITLE
fix: compile error following upgrade.md's vite to mix guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -539,14 +539,14 @@ You may also wish to remove any `.gitignore` paths you are no longer using:
 - /public/build
 ```
 
-Update postcss.config.js to use module.exports:
+Update `postcss.config.js` to use `module.exports`:
 
 ```diff
 - export default {
 + module.exports = {
 ```
 
-Remove `type` from package.json
+Remove `type` from `package.json`
 
 ```diff
 - "type": "module",

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -541,7 +541,7 @@ You may also wish to remove any `.gitignore` paths you are no longer using:
 
 Update postcss.config.js to use module.exports:
 
-```js
+```diff
 - export default {
 + module.exports = {
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -538,3 +538,10 @@ You may also wish to remove any `.gitignore` paths you are no longer using:
 - /bootstrap/ssr
 - /public/build
 ```
+
+Update postcss.config.js to use module.exports:
+
+```js
+- export default {
++ module.exports = {
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -271,7 +271,7 @@ Then you will need to specify the base URL for assets in your application's entr
 
 ### Optional: Configure Tailwind
 
-If you are using Tailwind, perhaps with one of Laravel's starter kits, you will need migrate your `tailwind.config.js` to use [Vite compatible imports](#vite-compatible-imports) and exports.
+If you are using Tailwind, perhaps with one of Laravel's starter kits, you will need to migrate your `tailwind.config.js` configuration file to use [Vite compatible imports](#vite-compatible-imports) and exports:
 
 ```diff
 - const defaultTheme = require('tailwindcss/defaultTheme');
@@ -459,6 +459,12 @@ Update your NPM scripts in `package.json`:
   }
 ```
 
+You should also remove the `type` key by running the following command:
+
+```shell
+npm pkg delete type
+```
+
 #### Inertia
 
 Vite requires a helper function to import page components which is not required with Laravel Mix. You can remove this as follows:
@@ -539,15 +545,54 @@ You may also wish to remove any `.gitignore` paths you are no longer using:
 - /public/build
 ```
 
-Update `postcss.config.js` to use `module.exports`:
+### Optional: Configure Tailwind
+
+If you are using Tailwind, perhaps with one of Laravel's starter kits, you will need to update your `tailwind.config.js` configuration file to use CommonJS imports and exports:
 
 ```diff
+- import defaultTheme from 'tailwindcss/defaultTheme';
+- import forms from '@tailwindcss/forms';
++ const defaultTheme = require('tailwindcss/defaultTheme');
+
 - export default {
 + module.exports = {
+    content: [
+        './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
+        './storage/framework/views/*.php',
+        './resources/views/**/*.blade.php',
+        './resources/js/**/*.vue',
+    ],
+
+    theme: {
+        extend: {
+            fontFamily: {
+                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+            },
+        },
+    },
+
+-    plugins: [forms],
++    plugins: [require('@tailwindcss/forms')],
+};
 ```
 
-Remove `type` from `package.json`
+You may also migrate any PostCSS plugins from your `postcss.config.js` file to your `webpack.mix.js` file:
 
 ```diff
-- "type": "module",
+ mix.js('resources/js/app.js', 'public/js')
+     .postCss('resources/css/app.css', 'public/css', [
+-        //
++        require("tailwindcss"),
+     ]);
+```
+
+> **Note**  
+> You do not need to include the `autoprefixer` plugin as Laravel Mix includes this by default.
+
+If you are using other PostCSS plugins, such as `postcss-import`, you will need to include them in your configuration. See the [Laravel Mix PostCSS documentation](https://laravel-mix.com/docs/6.0/postcss) for more information.
+
+Finally, you may also remove your PostCSS config file:
+
+```shell
+rm postcss.config.js
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -545,3 +545,9 @@ Update postcss.config.js to use module.exports:
 - export default {
 + module.exports = {
 ```
+
+Remove `type` from package.json
+
+```diff
+- "type": "module",
+```


### PR DESCRIPTION
Include fix for postcss.config.js when compiling assets

When a user follows the guide in `upgrade.md` to revert back to mix from vite, and then tries to compile they will most likely get an error, this pull request fixes that.