### PR TITLE
fix: support build in subfolders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-vite-plugin2",
+    "name": "laravel-vite-plugin",
     "version": "0.7.8",
     "description": "Laravel plugin for Vite.",
     "keywords": [
@@ -7,10 +7,10 @@
         "vite",
         "vite-plugin"
     ],
-    "homepage": "https://github.com/devhau/vite-plugin",
+    "homepage": "https://github.com/laravel/vite-plugin",
     "repository": {
         "type": "git",
-        "url": "https://github.com/devhau/vite-plugin"
+        "url": "https://github.com/laravel/vite-plugin"
     },
     "license": "MIT",
     "author": "Laravel",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-vite-plugin",
+    "name": "laravel-vite-plugin2",
     "version": "0.7.8",
     "description": "Laravel plugin for Vite.",
     "keywords": [
@@ -7,10 +7,10 @@
         "vite",
         "vite-plugin"
     ],
-    "homepage": "https://github.com/laravel/vite-plugin",
+    "homepage": "https://github.com/devhau/vite-plugin",
     "repository": {
         "type": "git",
-        "url": "https://github.com/laravel/vite-plugin"
+        "url": "https://github.com/devhau/vite-plugin"
     },
     "license": "MIT",
     "author": "Laravel",

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     inputs=[inputs];
                 }
                 if(Array.isArray(inputs)){
-                    inputs = inputs.map((item) => path.join(userConfig.root, item));
+                    inputs = inputs.map((item) => path.join(userConfig.root + '', item));
                 }
             }
             return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,20 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
     const defaultAliases: Record<string, string> = {
         '@': '/resources/js',
     };
-
+var listInputs =
+        userConfig.build?.rollupOptions?.input ??
+        resolveInput(pluginConfig, ssr);
+      if (listInputs && userConfig.root) {
+        if (Array.isArray(listInputs)) {
+          listInputs = listInputs.map((item) =>
+            userConfig.root ? path.join(userConfig.root, item) : item
+          );
+        } else if (!Array.isArray(listInputs) && listInputs != null) {
+          listInputs = userConfig.root
+            ? path.join(userConfig.root, listInputs + "")
+            : listInputs;
+        }
+      }
     return {
         name: 'laravel',
         enforce: 'post',
@@ -133,7 +146,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     manifest: userConfig.build?.manifest ?? !ssr,
                     outDir: userConfig.build?.outDir ?? resolveOutDir(pluginConfig, ssr),
                     rollupOptions: {
-                        input: userConfig.build?.rollupOptions?.input ?? resolveInput(pluginConfig, ssr)
+                        input: listInputs
                     },
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,19 +112,6 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
     const defaultAliases: Record<string, string> = {
         '@': '/resources/js',
     };
-    let listInputs = userConfig.build?.rollupOptions?.input ??
-        resolveInput(pluginConfig, ssr);
-      if (listInputs && userConfig.root) {
-        if (Array.isArray(listInputs)) {
-          listInputs = listInputs.map((item) =>
-            userConfig.root ? path.join(userConfig.root, item) : item
-          );
-        } else if (!Array.isArray(listInputs) && listInputs != null) {
-          listInputs = userConfig.root
-            ? path.join(userConfig.root, listInputs + "")
-            : listInputs;
-        }
-      }
     return {
         name: 'laravel',
         enforce: 'post',
@@ -138,6 +125,16 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
             ensureCommandShouldRunInEnvironment(command, env)
 
+            let inputs = userConfig.build?.rollupOptions?.input ?? resolveInput(pluginConfig, ssr);
+            if (inputs && userConfig.root) {
+                if (!Array.isArray(inputs)&&typeof inputs==='string') {
+                    inputs=[inputs];
+                }
+                if(Array.isArray(inputs)){
+                    inputs = inputs.map((item) =>
+                    userConfig.root ? path.join(userConfig.root, item) : item);
+                }
+            }
             return {
                 base: userConfig.base ?? (command === 'build' ? resolveBase(pluginConfig, assetUrl) : ''),
                 publicDir: userConfig.publicDir ?? false,
@@ -145,7 +142,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     manifest: userConfig.build?.manifest ?? !ssr,
                     outDir: userConfig.build?.outDir ?? resolveOutDir(pluginConfig, ssr),
                     rollupOptions: {
-                        input: listInputs
+                        input: inputs
                     },
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,8 +112,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
     const defaultAliases: Record<string, string> = {
         '@': '/resources/js',
     };
-var listInputs =
-        userConfig.build?.rollupOptions?.input ??
+    let listInputs = userConfig.build?.rollupOptions?.input ??
         resolveInput(pluginConfig, ssr);
       if (listInputs && userConfig.root) {
         if (Array.isArray(listInputs)) {


### PR DESCRIPTION
fix error: support build in subfolders
ex:
const vite = require("vite");
const pathSys = require("path");

function buildVite(root) {
  console.log(pathSys.join(root, "vite.config.js"));
  vite.build({
    root,
    configFile: pathSys.join(root, "vite.config.js"),
  });
}
buildVite('plugin/plugin1')
buildVite('plugin/plugin2')
buildVite('plugin/plugin2')
buildVite('plugin/plugin4')

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
