### PR TITLE
Upgrade vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "eslint": "^8.14.0",
         "typescript": "^4.6.4",
         "vite": "^4.0.0",
-        "vitest": "^0.25.2"
+        "vitest": "^0.34.4"
     },
     "peerDependencies": {
         "vite": "^3.0.0 || ^4.0.0"


### PR DESCRIPTION
This PR upgrades Vitest from ^0.25.2 to ^0.34.4 (latest).

### Reasons

The ecosystem-ci failed with https://github.com/vitejs/vite/pull/13944.
I'm not sure what the actual reason is, but it passed locally if I upgraded Vitest. Maybe Vitest was relying on CJS ssr feature in old versions.
I guess there won't be any problem with upgrading it.
