### PR TITLE
[0.8.x] [inertia-helpers] add support for fallback page component in `resolvePageComponent`

### DIFF
--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,12 +1,24 @@
-export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>, fallback?: string): Promise<T> {
+export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>, fallback?: string|((path: string) => Promise<T>)): Promise<T> {
     let page = pages[path]
 
-    if (typeof page === 'undefined') {
-        if (typeof fallback === 'undefined' || typeof pages[fallback] === 'undefined') {
-            throw new Error(`Page not found: ${path}`)
-        }
+    if (typeof page === 'undefined' && typeof fallback === 'string') {
         page = pages[fallback]
     }
 
-    return typeof page === 'function' ? page() : page
+    if (typeof page !== 'undefined') {
+        return typeof page === 'function' ? page() : page
+    }
+
+    if (typeof fallback === 'function') {
+        return fallback(path)
+    }
+
+    throw new PageNotFoundError(`Page not found: [${path}].`)
+}
+
+export class PageNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PageNotFoundError'
+  }
 }

--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,8 +1,11 @@
-export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>): Promise<T> {
-    const page = pages[path]
+export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>, fallback?: string): Promise<T> {
+    let page = pages[path]
 
     if (typeof page === 'undefined') {
-        throw new Error(`Page not found: ${path}`)
+        if (typeof fallback === 'undefined' || typeof pages[fallback] === 'undefined') {
+            throw new Error(`Page not found: ${path}`)
+        }
+        page = pages[fallback]
     }
 
     return typeof page === 'function' ? page() : page


### PR DESCRIPTION
When rendering a page using `Inertia::render('PageName')` if the `resources/js/Pages/PageName.vue` doesn't exist a blank white page is rendered with an error in the browser console.

With this PR I have added support for a default fallback component that will render in case of a missing page component. 

**Usage Example:**
Currently in `app.js` we are resolving pages like this

```js
createInertiaApp({
    title: (title) => `${title} - ${appName}`,
    resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
    setup({ el, App, props, plugin }) {
        return createApp({ render: () => h(App, props) })
            .use(plugin)
            .use(ZiggyVue)
            .mount(el);
    },
    progress: {
        color: '#4B5563',
    },
});
```

with an optional `fallback` parameter in `resolvePageComponent`, it will look like this:
```js
    resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue'), `./Pages/404.vue`),
```

here the third parameter can be any `.vue` file. If the `fallback` is defined but also missing it will through an error in the browser console.

**Benefits:**

When using dynamic routing one can now easily show an error page for missing pages when pages are mostly static

**Example of dynamic routing:**
```php
Route::get('/blog/{slug}', [ToolController::class, 'show']);
``` 
**Example Controller:**
```php
class ToolController extends Controller {
    public function index() {
        return Inertia::render('Blogs', []);
    }

    public function show($slug) {

        // Converting `test-url` to `TestUrl`
        $tool = explode('-', $slug);
        $toolComponent = implode('', array_map('ucfirst',$slug));

        $templateName = "Blogs/{$toolComponent}";
        return Inertia::render($templateName);
    }
}
``` 
**Example Existing Page Components:**
```
Pages/Blogs.vue
Pages/404.vue
Pages/Blogs/BlogPost1.vue
Pages/Blogs/BlogPost3.vue
Pages/Blogs/BlogPost4.vue
```

**Example URLs:**
```php
https://example.com/blog/blog-post-1 //valid
https://example.com/blog/blog-post-2 //invalid
``` 

With the modified name resolver, the first URL will load `BlogPost1.vue` as it's valid. But for the second URL `BlogPost2.vue` is missing. So it will take the fallback file `404.vue` and render that.