### PR TITLE
Handle Vite 5 types changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,9 +160,11 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                             ...serverConfig.hmr,
                             ...(userConfig.server?.hmr === true ? {} : userConfig.server?.hmr),
                         },
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                         // @ts-ignore `https: boolean` is removed in Vite 5
-                        https: userConfig.server?.https === false ? false as any : {
+                        https: userConfig.server?.https === false ? false as never : {
                             ...serverConfig.https,
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                             // @ts-ignore `https: boolean` is removed in Vite 5
                             ...(userConfig.server?.https === true ? {} : userConfig.server?.https),
                         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                             ...serverConfig.hmr,
                             ...(userConfig.server?.hmr === true ? {} : userConfig.server?.hmr),
                         },
-                        https: userConfig.server?.https === false ? false : {
+                        // @ts-ignore `https: boolean` is removed in Vite 5
+                        https: userConfig.server?.https === false ? false as any : {
                             ...serverConfig.https,
+                            // @ts-ignore `https: boolean` is removed in Vite 5
                             ...(userConfig.server?.https === true ? {} : userConfig.server?.https),
                         },
                     } : undefined),


### PR DESCRIPTION
Vite 5 removes the `https: boolean` type and as it doesn't have much use by default. A plugin or manual configuration is always needed for `https` to actually work (e.g. certs). (https://github.com/vitejs/vite/pull/14681)

This PR updates the types breaking change caused by it. It uses `@ts-ignore` so it works on both Vite 4 and 5. The `as any` is also needed so the `config` hook doesn't error by TS due to incorrect type returned by the function.

---

### Extra notes unrelated to PR

It seems like before (Vite 4), users could do `vite --https` or `https: true` in `vite.config.js` to get the right certs generate by `laravel-vite-plugin`. In Vite 5, this isn't possible anymore except if `https: {}` in `vite.config.js`. Though it isn't quite exactly documented in the [laravel docs](https://laravel.com/docs/10.x/vite#working-with-a-secure-development-server).

Just want to note this in case you want to handle this differently in the future. For example, the `detectTls` could be used to enable `https` internally. Right now it doesn't due to the existing logic here:

https://github.com/laravel/vite-plugin/blob/7abca675b82dd8a4fd23470f978110c3d083a0a1/src/index.ts#L163-L166