### PR TITLE
[0.8.x] Respect vite server.origin in viteDevServerUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
-                    viteDevServerUrl = resolvedConfig.server?.origin ? resolvedConfig.server.origin : resolveDevServerUrl(address, server.config, userConfig)
+                    viteDevServerUrl = resolvedConfig.server?.origin ? resolvedConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
                     fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
 
                     setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
-                    viteDevServerUrl = resolveDevServerUrl(address, server.config, userConfig)
+                    viteDevServerUrl = resolvedConfig.server.origin ? resolvedConfig.server.origin : resolveDevServerUrl(address, server.config, userConfig)
                     fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
 
                     setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
-                    viteDevServerUrl = resolvedConfig.server.origin ? resolvedConfig.server.origin : resolveDevServerUrl(address, server.config, userConfig)
+                    viteDevServerUrl = resolvedConfig.server?.origin ? resolvedConfig.server.origin : resolveDevServerUrl(address, server.config, userConfig)
                     fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
 
                     setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
-                    viteDevServerUrl = resolvedConfig.server?.origin ? resolvedConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
+                    viteDevServerUrl = userConfig.server?.origin ? userConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
                     fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
 
                     setTimeout(() => {


### PR DESCRIPTION
When running vite behind a reverse proxy, often you can get into situation where your publicly facing URL differs from the internally served URL, I am running into such an issue. 

My vite server is being served on `http://0.0.0.0:8080`, I am reverse proxying `http://0.0.0.0:8080` (via nginx) over to a domain `example.com`, so the publicly facing URL for my vite server is `https://example.com`. My browser has 0 access to `http://0.0.0.0:8080`, it is on a remote machine inside a container. I only have access to it via the reverse proxy.

This is usually solved by setting the `server.origin: 'https://example.com'` so all assets from vite are pointed to the right domain and location. But this `vite-plugin` does not respect the user configured `server.origin` and renders the plugin unusable in an environment that is using a reverse proxy in such a manor. 

