### PR TITLE
Fix types for moduleResolution=nodenext/bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         },
         "./inertia-helpers": {
             "import": "./inertia-helpers/index.js",
-            "types": "./inertia-helpers/index.d.ts",
             "node": "./inertia-helpers/index.js"
         }
     },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "exports": {
         ".": {
             "import": "./dist/index.mjs",
-            "require": "./dist/index.cjs",
-            "types": "./dist/index.d.ts"
+            "require": "./dist/index.cjs"
         },
         "./inertia-helpers": {
             "import": "./inertia-helpers/index.js",
@@ -34,7 +33,7 @@
     "scripts": {
         "build": "npm run build-plugin && npm run build-inertia-helpers",
         "build-plugin": "rm -rf dist && npm run build-plugin-types && npm run build-plugin-esm && npm run build-plugin-cjs && cp src/dev-server-index.html dist/",
-        "build-plugin-types": "tsc --emitDeclarationOnly",
+        "build-plugin-types": "tsc --emitDeclarationOnly && mv dist/index.d.ts dist/index.d.mts && cp dist/index.d.mts dist/index.d.cts",
         "build-plugin-cjs": "esbuild src/index.ts --platform=node --format=cjs --outfile=dist/index.cjs --define:import.meta.url=import_meta_url --inject:./import.meta.url-polyfill.js",
         "build-plugin-esm": "esbuild src/index.ts --platform=node --format=esm --outfile=dist/index.mjs",
         "build-inertia-helpers": "rm -rf inertia-helpers && tsc --project tsconfig.inertia-helpers.json",


### PR DESCRIPTION
The types condition was wrongly declared.
https://arethetypeswrong.github.io/?p=laravel-vite-plugin%400.8.1

This PR fixes that by

- Emitting both types for require and import for `.` export
  - A single type file cannot be used for both ESM and CJS. See https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md for more details.
- Removing types condition
  - `types` condition must be the first property. Instead of changing the order, I simply removed the condition because TypeScript will also look up the adjacent type file. See https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FallbackCondition.md for more details.