### PR TITLE
[0.8.x] Custom PageNotFoundError for resolvePageComponent

### DIFF
--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,8 +1,15 @@
+export class PageNotFoundError extends Error {
+    constructor(path: string) {
+        super(`Page not found: ${path}`)
+        this.name = 'PageNotFoundError'
+    }
+}
+
 export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>): Promise<T> {
     const page = pages[path]
 
     if (typeof page === 'undefined') {
-        throw new Error(`Page not found: ${path}`)
+        throw new PageNotFoundError(path)
     }
 
     return typeof page === 'function' ? page() : page

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import laravel from '../src'
-import { resolvePageComponent } from '../src/inertia-helpers';
+import { PageNotFoundError, resolvePageComponent } from '../src/inertia-helpers';
 
 describe('laravel-vite-plugin', () => {
     afterEach(() => {
@@ -375,5 +375,10 @@ describe('inertia-helpers', () => {
     it('pass eagerly globed value to resolvePageComponent', async () => {
         const file = await resolvePageComponent<{ default: string }>(path, import.meta.glob('./__data__/*.ts', { eager: true }))
         expect(file.default).toBe('Dummy File')
+    })
+
+    it('throws PageNotFoundError when path is not found', async () => {
+        const callback = () => resolvePageComponent<{ default: string }>('./__data__/_does_not_exist_.ts', import.meta.glob('./__data__/*.ts'))
+        await expect(callback).rejects.toThrowError(PageNotFoundError)
     })
 })


### PR DESCRIPTION
Currently a generic `Error` is thrown in `resolvePageComponent`, this PR changes that to a `PageNotFoundError`. This is particularly useful for projects that use React and want to transition from JS to TS. With this change it would be easier to load components from different locations/paths, or different file types such as `jsx` and `tsx`. With the custom exception it's a lot easier to check if the component doesn't exist or if it's another kind of error. An example in Inertia might look something like this:

```ts
import { createInertiaApp } from '@inertiajs/react'
import { resolvePageComponent, PageNotFoundError } from 'laravel-vite-plugin/inertia-helpers';
 
createInertiaApp({
  resolve: async (name) => {
    try {
      return await resolvePageComponent(`./Pages/${name}.jsx`, import.meta.glob('./Pages/**/*.jsx'))
    } catch (e) {
      if (e instanceof PageNotFoundError) {
        return await resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx'))
      }

      throw e
    }
  }
  // ...
})
```