### PR TITLE
[0.8.x] Fallback pages

### DIFF
--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,9 +1,13 @@
-export async function resolvePageComponent<T>(path: string, pages: Record<string, Promise<T> | (() => Promise<T>)>): Promise<T> {
-    const page = pages[path]
+export async function resolvePageComponent<T>(path: string|string[], pages: Record<string, Promise<T> | (() => Promise<T>)>): Promise<T> {
+    for (const p of (Array.isArray(path) ? path : [path])) {
+        const page = pages[p]
 
-    if (typeof page === 'undefined') {
-        throw new Error(`Page not found: ${path}`)
+        if (typeof page === 'undefined') {
+            continue
+        }
+
+        return typeof page === 'function' ? page() : page
     }
 
-    return typeof page === 'function' ? page() : page
+    throw new Error(`Page not found: ${path}`)
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -376,4 +376,9 @@ describe('inertia-helpers', () => {
         const file = await resolvePageComponent<{ default: string }>(path, import.meta.glob('./__data__/*.ts', { eager: true }))
         expect(file.default).toBe('Dummy File')
     })
+
+    it('accepts array of paths', async () => {
+        const file = await resolvePageComponent<{ default: string }>(['missing-page', path], import.meta.glob('./__data__/*.ts', { eager: true }), path)
+        expect(file.default).toBe('Dummy File')
+    })
 })


### PR DESCRIPTION
This PR is an alternative to https://github.com/laravel/vite-plugin/pull/252 and https://github.com/laravel/vite-plugin/pull/259.

It allows the `path` to be a string (current behaviour) or an array (new behaviour).

This enables two features:

1. A "fallback" so that users do not see a "whitescreen of death", where `./Pages/Whoops.vue` is the fallback:

```js
createInertiaApp({
    // ...
    resolve: (name) => resolvePageComponent([`./Pages/${name}.vue`, './Pages/Whoops.vue'], import.meta.glob('./Pages/**/*.vue')),
});
```

Of course, if the fallback isn't present things can still go wrong.

2. Easier migration from one file type to another without having to deal with error control, e.g., when migrating from `.jsx` to `.tsx`


```js
createInertiaApp({
    // ...
    resolve: (name) => resolvePageComponent([`./Pages/${name}.tsx`, `./Pages/${name}.jsx`], import.meta.glob('./Pages/**/*.[tj]sx')),
});
```