### PR TITLE
[1.x] Simpler conditional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                             ...serverConfig.hmr,
                             ...(userConfig.server?.hmr === true ? {} : userConfig.server?.hmr),
                         },
-                        https: typeof userConfig.server?.https !== 'undefined' ? userConfig.server.https : serverConfig.https,
+                        https: userConfig.server?.https ?? serverConfig.https,
                     } : undefined),
                 },
                 resolve: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,10 +162,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                             ...serverConfig.hmr,
                             ...(userConfig.server?.hmr === true ? {} : userConfig.server?.hmr),
                         },
-                        https: typeof userConfig.server?.https !== 'undefined' ? userConfig.server.https : {
-                            ...serverConfig.https,
-                            ...(typeof userConfig.server?.https === 'undefined' ? {} : userConfig.server?.https),
-                        },
+                        https: typeof userConfig.server?.https !== 'undefined' ? userConfig.server.https : serverConfig.https,
                     } : undefined),
                 },
                 resolve: {


### PR DESCRIPTION
`userConfig.server?.https` can either be undefined or be a user-defined object.

Currently there is an unnecessary conditional, because in the first ternary condition it is already checked if this configuration is undefined or not, therefor making the second ternary condition unnecessary. This PR solves this issue.