### PR TITLE
[1.x] Account for imported CSS files while cleaning

### DIFF
--- a/bin/clean.js
+++ b/bin/clean.js
@@ -54,7 +54,10 @@ const main = () => {
 
     const manifestAssets = isSsr
         ? manifestFiles.flatMap(key => manifest[key])
-        : manifestFiles.map(key => manifest[key].file)
+        : manifestFiles.flatMap(key => [
+            ...manifest[key].css ?? [],
+            manifest[key].file,
+        ])
 
     const assetsPath = argument('assets') ?? dirname(foundManifestPath)+'/assets'
 


### PR DESCRIPTION
Ensure that imported CSS files are not cleaned via `clean-orphaned-assets`.