### PR TITLE
[1.x] Fix exit error messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,9 +235,9 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 }
 
                 process.on('exit', clean)
-                process.on('SIGINT', process.exit)
-                process.on('SIGTERM', process.exit)
-                process.on('SIGHUP', process.exit)
+                process.on('SIGINT', () => process.exit())
+                process.on('SIGTERM', () => process.exit())
+                process.on('SIGHUP', () => process.exit())
 
                 exitHandlersBound = true
             }


### PR DESCRIPTION
Seems new node versions may have changed expected argument types here and are causing an issue.

Fixes https://github.com/laravel/vite-plugin/issues/274