### PR TITLE
[1.x] Fix HMR issue when `resources/lang` directory doesn't exist and a symlink is present in the root directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export const refreshPaths = [
     'resources/lang/**',
     'resources/views/**',
     'routes/**',
-]
+].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
 
 /**
  * Laravel plugin for Vite.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,6 +2,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import laravel from '../src'
 import { resolvePageComponent } from '../src/inertia-helpers';
 
+vi.mock('fs', async () => {
+    const actual = await vi.importActual<typeof import('fs')>('fs')
+
+    return {
+        default: {
+            ...actual,
+            existsSync: (path: string) => [
+                'app/Livewire/',
+                'app/View/Components/',
+                'resources/views/',
+                'lang/',
+                'routes/'
+            ].includes(path) || actual.existsSync(path)
+        }
+    }
+})
+
 describe('laravel-vite-plugin', () => {
     afterEach(() => {
         vi.clearAllMocks()
@@ -317,7 +334,6 @@ describe('laravel-vite-plugin', () => {
                 'app/Livewire/**',
                 'app/View/Components/**',
                 'lang/**',
-                'resources/lang/**',
                 'resources/views/**',
                 'routes/**',
             ],


### PR DESCRIPTION
This PR works around an obscure issue of HMR breaking when a symlink is present in the root directory along with one of the configured refresh paths not existing but sharing a common parent with a file being monitored.

While obscure, half of this combination can happen easily because we configure the `resources/lang` directory to be watched by default, but this no longer exists in the Laravel skeleton. All a user then needs to do to trigger the issue is to create any symlink in the project's root directory.

I couldn't track down exactly why this issue occurs, but it seems sensible to restrict the default refresh paths to only those that exist.

Fixes #284.