### PR TITLE
Append base to hot file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ interface LaravelPlugin extends Plugin {
     config: (config: UserConfig, env: ConfigEnv) => UserConfig
 }
 
-type DevServerUrl = `${'http'|'https'}://${string}:${number}`
+type DevServerUrl = `${'http'|'https'}://${string}:${number}${string}`
 
 let exitHandlersBound = false
 
@@ -431,8 +431,9 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig, userC
 
     const configHmrClientPort = typeof config.server.hmr === 'object' ? config.server.hmr.clientPort : null
     const port = configHmrClientPort ?? address.port
+    const base = config.base.replace(/\/$/, '')
 
-    return `${protocol}://${host}:${port}`
+    return `${protocol}://${host}:${port}${base}`
 }
 
 function isIpv6(address: AddressInfo): boolean {


### PR DESCRIPTION
fixes #288

Fixes an issue where the `base` path is not included in the `/public/hot` file. This issue only impacts the `npm run dev` command. When building, assets are appended with the configured base.

## `base` description

<img width="739" alt="Screenshot 2024-03-18 at 13 04 32" src="https://github.com/laravel/vite-plugin/assets/24803032/951d6bff-e86d-443f-a2ea-70c703295f2a">

## What

If we were to set the `base` path to `/frontend/`:

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    base: '/frontend/',
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            refresh: true,
        }),
    ],
});
```

Then the dev server will be appended with `/frontend/`:

<img width="415" alt="Screenshot 2024-03-18 at 13 08 15" src="https://github.com/laravel/vite-plugin/assets/24803032/0eae9679-5a09-4b2a-b0ec-10579e4cff84">

However, the hot file we write will not contain the `/frontend` base path:

<img width="360" alt="Screenshot 2024-03-18 at 13 08 43" src="https://github.com/laravel/vite-plugin/assets/24803032/28fff9d7-fe2c-46a5-a75f-d478716a969d">

So we do not create the correct URLs in Laravel. With this change in place, the hot file now contains the correct base.

<img width="410" alt="Screenshot 2024-03-18 at 13 12 26" src="https://github.com/laravel/vite-plugin/assets/24803032/bf791d07-6f28-4655-b28f-9897c3620cd7">

## Implementation notes

Vite normalizes the `base` value before we get access to it. The following table shows how Vite normalizes different values and what we end up appending to the hot file.

The only valid values for this option are `undefined`, an empty string, `./`, or an absolute URL, i.e., `https://example.com/...` or `/...`

| User config | Normalized | Hot file
| --- | --- | --- |
| `undefined` | `"/"` | `""` |
| `""` | `"/"` | `""` |
| `"/"` | `"/"` | `""` |
| `"./"` | `"/"` | `""` |
| `"/frontend"` | `"/frontend/"` | `"/frontend"` |
| `"/frontend/"` | `"/frontend/"` | `"/frontend"` |
| `"https://example.com"` | `"/"` | `""` |
| `"https://example.com/"` | `"/"` | `""` |
| `"https://example.com/frontend"` | `"/frontend/"` | `"/frontend"` |
| `"https://example.com/frontend/"` | `"/frontend/"` | `"/frontend"` |


