### PR TITLE
Include base in hotFile without modifying server.origin replacement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ interface LaravelPlugin extends Plugin {
     config: (config: UserConfig, env: ConfigEnv) => UserConfig
 }
 
-type DevServerUrl = `${'http'|'https'}://${string}:${number}${string}`
+type DevServerUrl = `${'http'|'https'}://${string}:${number}`
 
 let exitHandlersBound = false
 
@@ -204,7 +204,9 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
                 if (isAddressInfo(address)) {
                     viteDevServerUrl = userConfig.server?.origin ? userConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
-                    fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
+
+                    const base = server.config.base.replace(/\/$/, '')
+                    fs.writeFileSync(pluginConfig.hotFile, `${viteDevServerUrl}${base}`)
 
                     setTimeout(() => {
                         server.config.logger.info(`\n  ${colors.red(`${colors.bold('LARAVEL')} ${laravelVersion()}`)}  ${colors.dim('plugin')} ${colors.bold(`v${pluginVersion()}`)}`)
@@ -431,9 +433,8 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig, userC
 
     const configHmrClientPort = typeof config.server.hmr === 'object' ? config.server.hmr.clientPort : null
     const port = configHmrClientPort ?? address.port
-    const base = config.base.replace(/\/$/, '')
 
-    return `${protocol}://${host}:${port}${base}`
+    return `${protocol}://${host}:${port}`
 }
 
 function isIpv6(address: AddressInfo): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,8 +205,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 if (isAddressInfo(address)) {
                     viteDevServerUrl = userConfig.server?.origin ? userConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
 
-                    const base = server.config.base.replace(/\/$/, '')
-                    fs.writeFileSync(pluginConfig.hotFile, `${viteDevServerUrl}${base}`)
+                    fs.writeFileSync(pluginConfig.hotFile, `${viteDevServerUrl}${server.config.base.replace(/\/$/, '')}`)
 
                     setTimeout(() => {
                         server.config.logger.info(`\n  ${colors.red(`${colors.bold('LARAVEL')} ${laravelVersion()}`)}  ${colors.dim('plugin')} ${colors.bold(`v${pluginVersion()}`)}`)


### PR DESCRIPTION
Unfortunately #290 - while fixing the `hotFile` problem - broke the transform function's origin replacement when using a base in the configuration resulting in broken asset URLs.

Vite generates URLs using the `origin` and the `base`. As this plugin now replaces the `origin` (`__laravel_vite_placeholder__`) by default with the `origin+base`, the base is included twice in the asset URLs, which results in the given assets not loading.

On the other hand, the original problem that #290 solved was real as well, as Laravel did not take the `base` into account before this PR and the main files did not load when setting `base` in the configuration. This means that the `base` has to be included in the `hotFile`. It should also be included when setting the `origin` explicitly, which is a special case that #290 did not handle.

This pull request includes the `base` in the `hotFile`, but leaves the origin (or more precisely the replacement) as is. This should both solve the original problem and avoid including the `base` in the asset URLs twice.

|                    | before                                                                                     | after                                                                                      |
|--------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
| `public/hot` content | `https://test.localhost:443/vite-test-base`                                                  | `https://test.localhost:443/vite-test-base`                                                  |
| asset URL example  | `https://test.localhost/vite-test-base/vite-test-base/resources/images/test.svg`   | `https://test.localhost/vite-test-base/resources/images/test.svg`                  |
| chunk URL example  | `https://test.localhost/vite-test-base/node_modules/.vite/deps/chunk-NDQ3I6BD.js?v=df756ebe` | `https://test.localhost/vite-test-base/node_modules/.vite/deps/chunk-NDQ3I6BD.js?v=df756ebe` |

This change should not be a breaking change as it is a fix to something that changed in vite 5 compared to vite 4 as mentioned [here](https://github.com/laravel/vite-plugin/pull/290#issuecomment-2002774467).

