### PR TITLE
TypeScript: define entrypoints using object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,13 @@ import path from 'path'
 import colors from 'picocolors'
 import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
+import { InputOption } from "rollup"
 
 interface PluginConfig {
     /**
      * The path or paths of the entry points to compile.
      */
-    input: string|string[]
+    input: InputOption
 
     /**
      * Laravel's public directory.
@@ -37,7 +38,7 @@ interface PluginConfig {
     /**
      * The path of the SSR entry point.
      */
-    ssr?: string|string[]
+    ssr?: InputOption
 
     /**
      * The directory where the SSR bundle should be written.
@@ -368,7 +369,7 @@ function resolveBase(config: Required<PluginConfig>, assetUrl: string): string {
 /**
  * Resolve the Vite input path from the configuration.
  */
-function resolveInput(config: Required<PluginConfig>, ssr: boolean): string|string[]|undefined {
+function resolveInput(config: Required<PluginConfig>, ssr: boolean): InputOption|undefined {
     if (ssr) {
         return config.ssr
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -81,6 +81,45 @@ describe('laravel-vite-plugin', () => {
         expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.ts')
     })
 
+    it('accepts a single input within a full configuration', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+            ssr: 'resources/js/ssr.ts',
+        })[0]
+
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
+
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
+        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.ts')
+    })
+
+    it('accepts an array of inputs within a full configuration', () => {
+        const plugin = laravel({
+            input: ['resources/js/app.ts', 'resources/js/other.js'],
+            ssr: ['resources/js/ssr.ts', 'resources/js/other.js'],
+        })[0]
+
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(config.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
+
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
+        expect(ssrConfig.build.rollupOptions.input).toEqual(['resources/js/ssr.ts', 'resources/js/other.js'])
+    })
+
+    it('accepts an input object within a full configuration', () => {
+        const plugin = laravel({
+            input: { app: 'resources/js/entrypoint-browser.js' },
+            ssr: { ssr: 'resources/js/entrypoint-ssr.js' },
+        })[0]
+
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+        expect(config.build.rollupOptions.input).toEqual({ app: 'resources/js/entrypoint-browser.js' })
+
+        const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
+        expect(ssrConfig.build.rollupOptions.input).toEqual({ ssr: 'resources/js/entrypoint-ssr.js' })
+    })
+
     it('respects the users build.manifest config option', () => {
         const plugin = laravel({
             input: 'resources/js/app.js',


### PR DESCRIPTION
Vite & Rollup use the type `InputOption` for input entrypoints ([Rollup docs](https://rollupjs.org/configuration-options/#input)). The type definition is below ([source](https://github.com/rollup/rollup/blob/8ad322cc5ca2c1fe95b2bba41ba74d5aafe8054c/src/rollup/types.d.ts#L547)):

```ts
export type InputOption = string | string[] | { [entryAlias: string]: string };
```

However, the Laravel Vite Plugin currently only supports the type `string | string[]` for its input entrypoints.

This PR changes the `input` and `ssr` fields to use Rollup's `InputOption`, enabling users to specify the names of their entrypoint's output files. This behavior is already supported by the Laravel Vite Plugin, but TypeScript currently shows warnings in `vite.config.ts` when an object is used to specify entrypoints in the `input` or `ssr` fields.

Here is what it looks like to specify output filenames using an object in Vite:

```js
export default defineConfig({
  plugins: [
    laravel({
      input: {
        "output-filename.js": "resources/js/input-filename.js",
      },
    }),
  ],
});
```

The PR also adds tests to ensure that the `input` and `ssr` fields will accept a string, array of strings, and input object.