### PR TITLE
Look for certificates in valet linux config directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                                 server.config.logger.info(`  ${colors.green('➜')}  Using Herd certificate to secure Vite.`)
                             }
 
-                            if (resolvedConfig.server.https.key.startsWith(valetMacConfigPath())) {
+                            if (resolvedConfig.server.https.key.startsWith(valetMacConfigPath()) || resolvedConfig.server.https.key.startsWith(valetLinuxConfigPath())) {
                                 server.config.logger.info(`  ${colors.green('➜')}  Using Valet certificate to secure Vite.`)
                             }
                         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,6 +583,10 @@ function determineDevelopmentEnvironmentConfigPath(): string|undefined {
     if (fs.existsSync(valetConfigPath())) {
         return valetConfigPath()
     }
+
+    if (fs.existsSync(valetLinuxConfigPath())) {
+        return valetLinuxConfigPath()
+    }
 }
 
 /**
@@ -626,4 +630,11 @@ function herdWindowsConfigPath(): string {
  */
 function valetConfigPath(): string {
     return path.resolve(os.homedir(), '.config', 'valet')
+}
+
+/**
+ * Valet Linux's configuration directory.
+ */
+function valetLinuxConfigPath(): string {
+    return path.resolve(os.homedir(), '.valet')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                                 server.config.logger.info(`  ${colors.green('➜')}  Using Herd certificate to secure Vite.`)
                             }
 
-                            if (resolvedConfig.server.https.key.startsWith(valetConfigPath())) {
+                            if (resolvedConfig.server.https.key.startsWith(valetMacConfigPath())) {
                                 server.config.logger.info(`  ${colors.green('➜')}  Using Valet certificate to secure Vite.`)
                             }
                         }
@@ -580,8 +580,8 @@ function determineDevelopmentEnvironmentConfigPath(): string|undefined {
         return herdWindowsConfigPath()
     }
 
-    if (fs.existsSync(valetConfigPath())) {
-        return valetConfigPath()
+    if (fs.existsSync(valetMacConfigPath())) {
+        return valetMacConfigPath()
     }
 
     if (fs.existsSync(valetLinuxConfigPath())) {
@@ -626,9 +626,9 @@ function herdWindowsConfigPath(): string {
 }
 
 /**
- * Valet's configuration directory.
+ * Valet's Mac configuration directory.
  */
-function valetConfigPath(): string {
+function valetMacConfigPath(): string {
     return path.resolve(os.homedir(), '.config', 'valet')
 }
 


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hi, this pull request adds another search path to support the [valet-linux](https://github.com/cpriego/valet-linux) project.

I understand that this project isn't officially supported, but a small change in this Vite plugin would allow our team to greatly simplify our Vite configuration and support developers using Linux or Mac with Herd.
