### PR TITLE
Upgrade to Vite 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 22.x, latest]
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -49,14 +49,14 @@
         "esbuild": "0.16.10",
         "eslint": "^8.14.0",
         "typescript": "^4.6.4",
-        "vite": "^5.0.0",
+        "vite": "^6.0.0",
         "vitest": "^0.34.4"
     },
     "peerDependencies": {
-        "vite": "^5.0.0"
+        "vite": "^6.0.0"
     },
     "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
     },
     "dependencies": {
         "picocolors": "^1.0.0",


### PR DESCRIPTION
Upgrades supported Vite version to the recently released Vite 6.

Read more: https://vite.dev/blog/announcing-vite6

## Breeze testing
- [x] Blade with Alpine
- [x] Livewire (Volt Class API) with Alpine
- [x] Livewire (Volt Functional API) with Alpine
- [x] React with Inertia
- [x] Vue with Inertia

## Jetstream testing

- [x] Vue
- [x] Livewire

## Related PRs

- https://github.com/laravel/laravel/pull/6498
- https://github.com/laravel/laravel.com/pull/374
- https://github.com/laravel/bootcamp.laravel.com/pull/86
- https://github.com/laravel/package-template/pull/13
- https://github.com/laravel/vapor-laravel-template/pull/1