### PR TITLE
[1.x] Fix Invalid URL issue with Vite 6.0.9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
         },
         transform(code) {
             if (resolvedConfig.command === 'serve') {
-                code = code.replace(/__laravel_vite_placeholder__/g, viteDevServerUrl)
+                code = code.replace(/http:\/\/__laravel_vite_placeholder__\.test/g, viteDevServerUrl)
 
                 return pluginConfig.transformOnServe(code, viteDevServerUrl)
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },
                 server: {
-                    origin: userConfig.server?.origin ?? 'http://laravel-vite-plugin.test',
+                    origin: userConfig.server?.origin ?? 'http://__laravel_vite_placeholder__.test',
                     ...(process.env.LARAVEL_SAIL ? {
                         host: userConfig.server?.host ?? '0.0.0.0',
                         port: userConfig.server?.port ?? (env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173),

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },
                 server: {
-                    origin: userConfig.server?.origin ?? '__laravel_vite_placeholder__',
+                    origin: userConfig.server?.origin ?? 'http://laravel-vite-plugin.test',
                     ...(process.env.LARAVEL_SAIL ? {
                         host: userConfig.server?.host ?? '0.0.0.0',
                         port: userConfig.server?.port ?? (env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173),


### PR DESCRIPTION
This PR resolves the “Invalid URL” error encountered when running npm run dev or npm run build. The issue arises from the requirement introduced in Vite 6.0.9 that server.origin must be a valid URL. The configuration has been updated to comply with this requirement.

```
error when starting dev server:
TypeError: Invalid URL
    at new URL (node:internal/url:818:25)
    ...
```
This commit updates the default server.origin value in laravel-vite-plugin from `__laravel_vite_placeholder__` to `http://laravel-vite-plugin.test`. This change resolves the “Invalid URL” error that occurred when attempting to create a URL with the server.origin value following the update to Vite 6.0.9, which enforces server.origin to be a valid URL.

The updated value has been tested in Vite 6.0.8 and earlier versions, confirming compatibility and no issues when used as a valid link.

[Vite 6.0.9 changes](https://github.com/vitejs/vite/commit/bd896fb5f312fc0ff1730166d1d142fc0d34ba6d#diff-6a05692e5309964f6c90cd5f8ae8ae9b8fc9ad4297ccef6706d1d5a73f3acb39R40)

