### PR TITLE
[1.x] Add default CORS origins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,14 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 },
                 server: {
                     origin: userConfig.server?.origin ?? '__laravel_vite_placeholder__',
+                    cors: userConfig.server?.cors ?? {
+                        origin: userConfig.server?.origin ?? [
+                            ...(env.APP_URL ? [env.APP_URL] : []),   // *               (APP_URL="http://my-app.tld")
+                            /^https?:\/\/127\.0\.0\.1(:\d+)?$/,      // Artisan serve   (SCHEME://127.0.0.1:PORT)
+                            /^https?:\/\/.*\.test(:\d+)?$/,          // Valet / Herd    (SCHEME://*.test:PORT)
+                            /^https?:\/\/localhost(:\d+)?$/,         // Docker          (SCHEME://localhost:PORT)
+                        ],
+                    },
                     ...(process.env.LARAVEL_SAIL ? {
                         host: userConfig.server?.host ?? '0.0.0.0',
                         port: userConfig.server?.port ?? (env.VITE_PORT ? parseInt(env.VITE_PORT) : 5173),

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,10 +154,9 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     origin: userConfig.server?.origin ?? '__laravel_vite_placeholder__',
                     cors: userConfig.server?.cors ?? {
                         origin: userConfig.server?.origin ?? [
+                            /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
                             ...(env.APP_URL ? [env.APP_URL] : []),   // *               (APP_URL="http://my-app.tld")
-                            /^https?:\/\/127\.0\.0\.1(:\d+)?$/,      // Artisan serve   (SCHEME://127.0.0.1:PORT)
                             /^https?:\/\/.*\.test(:\d+)?$/,          // Valet / Herd    (SCHEME://*.test:PORT)
-                            /^https?:\/\/localhost(:\d+)?$/,         // Docker          (SCHEME://localhost:PORT)
                         ],
                     },
                     ...(process.env.LARAVEL_SAIL ? {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
 import laravel from '../src'
 import { resolvePageComponent } from '../src/inertia-helpers';
+import path from 'path';
 
 vi.mock('fs', async () => {
     const actual = await vi.importActual<typeof import('fs')>('fs')
@@ -448,6 +450,80 @@ describe('laravel-vite-plugin', () => {
             paths: ['another/to/watch/**'],
             config: { delay: 123 }
         })
+    })
+
+    it('configures default cors.origin values', () => {
+        const test = (pattern: RegExp|string, value: string) => pattern instanceof RegExp ? pattern.test(value) : pattern === value
+        fs.writeFileSync(path.join(__dirname, '.env'), 'APP_URL=http://example.com')
+
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+        })
+        const resolvedConfig = plugins[0].config({ envDir: __dirname }, {
+            mode: '',
+            command: 'serve'
+        })
+
+        // Allowed origins...
+        expect([
+            // localhost
+            'http://localhost',
+            'https://localhost',
+            'http://localhost:8080',
+            'https://localhost:8080',
+            // 127.0.0.1
+            'http://127.0.0.1',
+            'https://127.0.0.1',
+            'http://127.0.0.1:8000',
+            'https://127.0.0.1:8000',
+            // *.test
+            'http://laravel.test',
+            'https://laravel.test',
+            'http://laravel.test:8000',
+            'https://laravel.test:8000',
+            'http://my-app.test',
+            'https://my-app.test',
+            'http://my-app.test:8000',
+            'https://my-app.test:8000',
+            'https://my-app.test:8',
+            // APP_URL
+            'http://example.com',
+        ].some((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(true)
+        // Disallowed origins...
+        expect([
+            'http://laravel.com',
+            'https://laravel.com',
+            'http://laravel.com:8000',
+            'https://laravel.com:8000',
+            'http://128.0.0.1',
+            'https://128.0.0.1',
+            'http://128.0.0.1:8000',
+            'https://128.0.0.1:8000',
+            'https://example.com',
+            'http://example.com:8000',
+            'https://example.com:8000',
+            'http://exampletest',
+            'http://example.test:',
+        ].some((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(false)
+
+        fs.rmSync(path.join(__dirname, '.env'))
+    })
+
+    it("respects the user's server.cors config", () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+        })
+        const resolvedConfig = plugins[0].config({
+            envDir: __dirname,
+            server: {
+                cors: true,
+            }
+        }, {
+            mode: '',
+            command: 'serve'
+        })
+
+        expect(resolvedConfig.server.cors)
     })
 })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -524,7 +524,7 @@ describe('laravel-vite-plugin', () => {
             command: 'serve'
         })
 
-        expect(resolvedConfig.server.cors)
+        expect(resolvedConfig.server.cors).toBe(true)
     })
 })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -488,6 +488,7 @@ describe('laravel-vite-plugin', () => {
             'https://my-app.test:8',
             // APP_URL
             'http://example.com',
+            'https://subdomain.my-app.test',
         ].some((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(true)
         // Disallowed origins...
         expect([


### PR DESCRIPTION
## The issue

Vite recently patched a vulnerability in their dev server (https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6).

The tl;dr; of the vulnerability: is allows _any_ website to listen to a running dev server on the user's local computer and access the source code.

On my local machine, when I'm running `npm run dev` I could visit the following HTML hosted on any website, e.g., `https://tim.macdonald.au/vite-listener`, and the site would be able to listen to the dev server and potentially access source code.

<img width="883" alt="Screenshot 2025-01-21 at 13 24 17" src="https://github.com/user-attachments/assets/647aba40-9e17-4bbe-9674-b88a9f5a4bee" />

This issue was caused by Vite allowing `'*'` as the CORS origin by default. Now, applications must specify the allowed origins.

The result of this patch for Laravel applications is that we now get CORS errors when running the dev server.

## The manual solution

Specify the Laravel application's origin in the Vite config:

```diff
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            refresh: true,
        }),
    ],
+
+   server: {
+       cors: {
+           origin: 'https://my-app.test'
+       },
+   },
});
```

I don't love that this config needs to be in place in the default `laravel/laravel` config file. Additionally, I don't love that this fix needs to be done manually across all existing Laravel applications because we don't know what host the site is being accessed through.

Hardcoding is also not great when developers may run their web server in different ways, e.g., Herd or Artisan serve, resulting in different origins.

We could read the `APP_URL` but it is often not updated, and does not need to be, in order for the app to work.

## The conventional solution

The goal of this PR is to provide a config-free solution for the 80% use case while still offering the above manual solution for applications with unique requirements.

Out of the box, the `laravel-vite-plugin` will autofill the `server.cors.origin` config allowing the following CORS origins:

- `APP_URL`
- `http(s)://127.0.0.1`
- `http(s)://localhost`
- `http(s)://{PROJECT_DIRECTORY}.test`

All of these also allow for a port to be specified.

With this in place, we should have out-of-the-box CORS support for:

- Artisan serve
- Sail (Docker)
- Herd / Valet
- Anything else via the `APP_URL`

These also feel like safe defaults that should not expose us to the Vite vulnerability.

Vite also allows `.localhost` domains out of the box.

## These defaults do not work for me

If you set your `APP_URL` to whatever domain you server Laravel from, things should work as you need. If you _really_ need special CORS customisations while locally running the dev server, you may add your own config:

```diff
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.js'],
            refresh: true,
        }),
    ],
+
+   server: {
+       cors: {
+           origin: 'https://my-app.au-1.sharedwithexpose.com'
+       },
+   },
});
```