### PR TITLE
Add plugin option `runAfterServe`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,11 @@ interface PluginConfig {
      * Transform the code while serving.
      */
     transformOnServe?: (code: string, url: DevServerUrl) => string,
+
+    /**
+     * Run a callback each time Vite is stopped
+     */
+    runAfterServe?: (config: ResolvedConfig) => void,
 }
 
 interface RefreshConfig {
@@ -240,7 +245,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     }
                 }
 
-                process.on('exit', clean)
+                process.on('exit', () => {
+                    clean();
+                    pluginConfig.runAfterServe?.(resolvedConfig);
+                })
                 process.on('SIGINT', () => process.exit())
                 process.on('SIGTERM', () => process.exit())
                 process.on('SIGHUP', () => process.exit())
@@ -363,6 +371,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         valetTls: config.valetTls ?? null,
         detectTls: config.detectTls ?? config.valetTls ?? null,
         transformOnServe: config.transformOnServe ?? ((code) => code),
+        runAfterServe: config.runAfterServe ?? (() => {})
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ interface PluginConfig {
     /**
      * Run a callback each time Vite is stopped
      */
-    runAfterServe?: (config: ResolvedConfig) => void,
+    runAfterServe?: ((config: ResolvedConfig) => void)|null,
 }
 
 interface RefreshConfig {
@@ -371,7 +371,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         valetTls: config.valetTls ?? null,
         detectTls: config.detectTls ?? config.valetTls ?? null,
         transformOnServe: config.transformOnServe ?? ((code) => code),
-        runAfterServe: config.runAfterServe ?? (() => {})
+        runAfterServe: config.runAfterServe ?? null
     }
 }
 


### PR DESCRIPTION
Add a new plugin option `runAfterServe`. The option allows to run an arbitrary callback each time `vite` or `vite serve` is cancelled.

## Use Case

When running `vite serve` (or `vite`), the asset state can drift from the last build. Automatically running `vite build` on exit ensures the assets folder stays up-to-date.  

## Usage

```ts
import { defineConfig } from "vite";
import laravel from "laravel-vite-plugin";
import { execSync } from "child_process";

export default defineConfig(async ({ mode }) => {
  return {
    plugins: [
      laravel({
        runAfterServe: () => {
          /** build assets each time serve is stopped */
          execSync("pnpm run build");
        },
      }),
    ]
  };
});

```

## Why include this in `laravel-vite-plugin`  

- Laravel (and most PHP sites) are usually served via an independent dev server (e.g., Herd, Valet, ddev). This means it's easy to access the site when Vite isn't running, potentially leading to outdated assets. Automatically running `build` on exit ensures a consistent asset state.  
- `laravel-vite-plugin` already has a robust exit handler for removing the hot file (kudos for that!). Adding a custom callback here introduces minimal overhead while providing significant benefits for developers who rely on this behavior.  

## Alternatives Considered

Maintain an independent vite plugin. An example can be found here: https://gist.github.com/hirasso/604e3776ecfb402c8513154a8ae46cba

## Naming

- `runAfterServe`?
- `onExit`?
- `cleanup`?
