### PR TITLE
Ignore .DS_Store and common package manager lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.DS_Store
 /node_modules/
 /dist/
 /inertia-helpers/
 /npm-debug.log
 /package-lock.json
+/pnpm-lock.yaml
+/yarn.lock


### PR DESCRIPTION
- ignore .DS_Store
- ignore pnpm-lock.yaml
- ignore yarn.lock

As discussed in #320 , it is the opinion of laravel-vite-plugin to not check in package manager lock files. Also, no specific package manger should be enforced as explained by @timacdonald in the [issue comment](https://github.com/laravel/vite-plugin/issues/320#issuecomment-2655010429). 

If this is actually the intention, all common package manager lock files should be ignored in the `.gitignore` file, to prevent committing them by accident.