### PR TITLE
[1.x] Hot file monitoring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,8 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const content = new Promise<string>((resolve) => resolve(update.read()))
 
             viteDevServerUrl = (await content).trim() as DevServerUrl
+
+            update.server.ws.send({ type: 'full-reload' })
         },
         transform(code) {
             if (resolvedConfig.command === 'serve') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,7 +359,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         ssr: config.ssr ?? config.input,
         ssrOutputDirectory: config.ssrOutputDirectory ?? 'bootstrap/ssr',
         refresh: config.refresh ?? false,
-        hotFile: config.hotFile ?? path.join((config.publicDirectory ?? 'public'), 'hot'),
+        hotFile: path.resolve(config.hotFile ?? path.join((config.publicDirectory ?? 'public'), 'hot')),
         valetTls: config.valetTls ?? null,
         detectTls: config.detectTls ?? config.valetTls ?? null,
         transformOnServe: config.transformOnServe ?? ((code) => code),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,13 @@ import os from 'os'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import colors from 'picocolors'
-import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption } from 'vite'
+import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, createLogger } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
 import { InputOption } from "rollup"
+
+const logger = createLogger('info', {
+    prefix: '[laravel-vite-plugin]'
+})
 
 interface PluginConfig {
     /**
@@ -205,6 +209,11 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             viteDevServerUrl = (await content).trim() as DevServerUrl
 
             update.server.ws.send({ type: 'full-reload' })
+
+            logger.info(`${colors.green('page reload')} Hot file changed ${colors.dim(viteDevServerUrl)}`, {
+                timestamp: true,
+                clear: true,
+            })
         },
         transform(code) {
             if (resolvedConfig.command === 'serve') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,15 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
         configResolved(config) {
             resolvedConfig = config
         },
+        async handleHotUpdate(update) {
+            if (update.file !== pluginConfig.hotFile) {
+                return
+            }
+
+            const content = new Promise<string>((resolve) => resolve(update.read()))
+
+            viteDevServerUrl = (await content).trim() as DevServerUrl
+        },
         transform(code) {
             if (resolvedConfig.command === 'serve') {
                 code = code.replace(/http:\/\/__laravel_vite_placeholder__\.test/g, viteDevServerUrl)


### PR DESCRIPTION
This PR allows 3rd party tools, such as [Expose](https://expose.dev/docs/introduction),  to control the URL in the hot file. The URL in the hot file is used by both Laravel and Vite when rendering URLs to the Vite server.

When the URL in the hot file is updated, the plugin will use the new URL when rendering URLs in JS and CSS assets. It will also perform a full page reload when the hot file is updated which should be a nice DX, e.g., when Expose starts it can write a new URL to the hot file, handle proxying that URL back to the Vite server, and the page will refresh to start using the new dev server URL all automatically.

An example log, which matches how Vite formats their log messages for similar events:

<img width="907" alt="Screenshot 2025-02-21 at 10 54 46" src="https://github.com/user-attachments/assets/8272ba4e-579e-4a4e-894b-1be0b2737b96" />
