### PR TITLE
Use rollup types from Vite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,14 @@ import os from 'os'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import colors from 'picocolors'
-import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption } from 'vite'
+import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rollup } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
-import { InputOption } from "rollup"
 
 interface PluginConfig {
     /**
      * The path or paths of the entry points to compile.
      */
-    input: InputOption
+    input: Rollup.InputOption
 
     /**
      * Laravel's public directory.
@@ -38,7 +37,7 @@ interface PluginConfig {
     /**
      * The path of the SSR entry point.
      */
-    ssr?: InputOption
+    ssr?: Rollup.InputOption
 
     /**
      * The directory where the SSR bundle should be written.

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,7 +375,7 @@ function resolveBase(config: Required<PluginConfig>, assetUrl: string): string {
 /**
  * Resolve the Vite input path from the configuration.
  */
-function resolveInput(config: Required<PluginConfig>, ssr: boolean): InputOption|undefined {
+function resolveInput(config: Required<PluginConfig>, ssr: boolean): Rollup.InputOption|undefined {
     if (ssr) {
         return config.ssr
     }


### PR DESCRIPTION
Since `rollup` is not declared as a dependency or a peerDependency, this import fails in some cases (see https://rushjs.io/pages/advanced/phantom_deps/ for more details).

That was causing the ecosystem-ci to fail.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/14437826501/job/40481878417#step:8:697

This PR fixes that by using the re-exported types from Vite.

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
