### PR TITLE
Automatically create hotFile parent directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,12 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                 if (isAddressInfo(address)) {
                     viteDevServerUrl = userConfig.server?.origin ? userConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
 
+                    const hotFileParentDirectory = path.dirname(pluginConfig.hotFile);
+
+                    if (!fs.existsSync(hotFileParentDirectory)) {
+                        fs.mkdirSync(hotFileParentDirectory, { recursive: true })
+                    }
+
                     fs.writeFileSync(pluginConfig.hotFile, `${viteDevServerUrl}${server.config.base.replace(/\/$/, '')}`)
 
                     setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                     if (! fs.existsSync(hotFileParentDirectory)) {
                         fs.mkdirSync(hotFileParentDirectory, { recursive: true })
+
+                        setTimeout(() => {
+                            server.config.logger.info(`${colors.green('laravel')} Hot file directory created ${colors.dim(fs.realpathSync(hotFileParentDirectory))}`, { clear: true, timestamp: true })
+                        }, 200)
                     }
 
                     fs.writeFileSync(pluginConfig.hotFile, `${viteDevServerUrl}${server.config.base.replace(/\/$/, '')}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
                     const hotFileParentDirectory = path.dirname(pluginConfig.hotFile);
 
-                    if (!fs.existsSync(hotFileParentDirectory)) {
+                    if (! fs.existsSync(hotFileParentDirectory)) {
                         fs.mkdirSync(hotFileParentDirectory, { recursive: true })
                     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import os from 'os'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import colors from 'picocolors'
-import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rollup } from 'vite'
+import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rollup, createLogger } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
 
 interface PluginConfig {
@@ -96,6 +96,10 @@ export const refreshPaths = [
     'resources/views/**',
     'routes/**',
 ].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
+
+const logger = createLogger('info', {
+    prefix: '[laravel-vite-plugin]'
+})
 
 /**
  * Laravel plugin for Vite.
@@ -218,7 +222,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                         fs.mkdirSync(hotFileParentDirectory, { recursive: true })
 
                         setTimeout(() => {
-                            server.config.logger.info(`${colors.green('laravel')} Hot file directory created ${colors.dim(fs.realpathSync(hotFileParentDirectory))}`, { clear: true, timestamp: true })
+                            logger.info(`Hot file directory created ${colors.dim(fs.realpathSync(hotFileParentDirectory))}`, { clear: true, timestamp: true })
                         }, 200)
                     }
 


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I have the following `vite.config.ts`:

```ts
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react";
import laravel from "laravel-vite-plugin";
import tailwindcss from '@tailwindcss/vite'

export default defineConfig({
    plugins: [
        tailwindcss(),
        laravel({
            input: ["src/App.tsx"],
            publicDirectory: "../wwwroot",
            hotFile: "../wwwroot/build/hot",
            refresh: true,
        }),
        react(),
    ],
    resolve: {
        alias: {
            "@": "/src",
        },
    },
    build: {
        emptyOutDir: true,
    },
});

```

When I run `npm run dev` on a fresh clone, I usually have to make the directory by hand. It would be nice if this library just did automatically. 