### PR TITLE
Handle `pages` parameter being `Record<string, T>` in  `resolvePageComponent` helper

### DIFF
--- a/src/inertia-helpers/index.ts
+++ b/src/inertia-helpers/index.ts
@@ -1,4 +1,4 @@
-export async function resolvePageComponent<T>(path: string|string[], pages: Record<string, Promise<T> | (() => Promise<T>)>): Promise<T> {
+export async function resolvePageComponent<T>(path: string|string[], pages: Record<string, T | Promise<T> | (() => Promise<T>)>): Promise<T> {
     for (const p of (Array.isArray(path) ? path : [path])) {
         const page = pages[p]
 
@@ -6,7 +6,9 @@ export async function resolvePageComponent<T>(path: string|string[], pages: Reco
             continue
         }
 
-        return typeof page === 'function' ? page() : page
+        return typeof page === 'function'
+            ? (page as () => Promise<T>)()
+            : page
     }
 
     throw new Error(`Page not found: ${path}`)


### PR DESCRIPTION
If page components are eagerly imported with something like this
```ts
const pages = import.meta.glob<DefineComponent>('./pages/**/*.vue', { eager: true });

return resolvePageComponent<DefineComponent>(`./pages/${name}.vue`, pages);
```

You get this warning from typescript
```
Argument of type 'Record<string, DefineComponent>' is not assignable to parameter of type 'Record<string, Promise<DefineComponent> | (() => Promise<DefineComponent>)>'.
  'string' index signatures are incompatible.
    Type 'DefineComponent' is not assignable to type 'Promise<DefineComponent> | (() => Promise<DefineComponent>)'.
      Type 'DefineComponent' is not assignable to type 'Promise<DefineComponent>'
```

It's not that big of a deal and it doesn't prevent compiling but it's annoying to look at. I just thought that it could be improved.

This PR doesn't change the functionality in any way, it just improves the type support.
