### PR TITLE
fix: missing 2.0.0 release notes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased](https://github.com/laravel/vite-plugin/compare/v2.0.1...2.x)
 
-## [v2.0.1](https://github.com/laravel/vite-plugin/compare/v1.3.0...v2.0.1) - 2025-08-26
+## [v2.0.1](https://github.com/laravel/vite-plugin/compare/v2.0.0...v2.0.1) - 2025-08-26
 
 * Automatically create hotFile parent directory by [@adrum](https://github.com/adrum) in https://github.com/laravel/vite-plugin/pull/334
+
+## [v2.0.0](https://github.com/laravel/vite-plugin/compare/v1.3.0...v2.0.0) - 2025-07-09
+
+* Vite 7 support by [@sweptsquash](https://github.com/sweptsquash) in https://github.com/laravel/vite-plugin/pull/328
+* Upgrade dependencies by [@timacdonald](https://github.com/timacdonald) in https://github.com/laravel/vite-plugin/pull/331
 
 ## [v1.3.0](https://github.com/laravel/vite-plugin/compare/v1.2.0...v1.3.0) - 2025-06-03
 


### PR DESCRIPTION
I went to update my dependencies and before I did, I checked the release notes for the latest version. I saw no breaking changes so I bumped my version and installed. Except it wouldn’t install. I got an error saying that Vite 7 is required. I checked the changelog and saw no such note about the update/change.

Turns out the notes for 2.0.0 were missing that described the change.