### PR TITLE
[2.x] Use vite export to future proof additional pattern changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import os from 'os'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import colors from 'picocolors'
-import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rollup, createLogger } from 'vite'
+import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rollup, createLogger, defaultAllowedOrigins } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
 
 interface PluginConfig {
@@ -157,7 +157,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     origin: userConfig.server?.origin ?? 'http://__laravel_vite_placeholder__.test',
                     cors: userConfig.server?.cors ?? {
                         origin: userConfig.server?.origin ?? [
-                            /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/, // Copied from Vite itself. We can import this once we drop 5.0 support and require Vite 6.1+. Source: https://github.com/vitejs/vite/blob/0c854645bd17960abbe8f01b602d1a1da1a2b9fd/packages/vite/src/node/constants.ts#L200-L201
+                            defaultAllowedOrigins,
                             ...(env.APP_URL ? [env.APP_URL] : []),                                  // *               (APP_URL="http://my-app.tld")
                             /^https?:\/\/.*\.test(:\d+)?$/,                                         // Valet / Herd    (SCHEME://*.test:PORT)
                         ],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -489,7 +489,7 @@ describe('laravel-vite-plugin', () => {
             // APP_URL
             'http://example.com',
             'https://subdomain.my-app.test',
-        ].some((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(true)
+        ].every((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(true)
         // Disallowed origins...
         expect([
             'http://laravel.com',
@@ -505,7 +505,7 @@ describe('laravel-vite-plugin', () => {
             'https://example.com:8000',
             'http://exampletest',
             'http://example.test:',
-        ].some((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(false)
+        ].every((url) => resolvedConfig.server.cors.origin.some((regex) => test(regex, url)))).toBe(false)
 
         fs.rmSync(path.join(__dirname, '.env'))
     })


### PR DESCRIPTION
Some time ago, Vite patches a vulnerability in their dev server and we augmented their patch with our communities conventional TLD, i.e., `.test`, as well as the project's configured URL.

At the time, we have to copy Vite's regex into the project as it wasn't exposed anywhere for us.

I got the value exported in https://github.com/vitejs/vite/pull/19259, which was tagged in a 6.x release. We now require 7.x with the plugin, so we can safely replace the value with Vite's exported value to forward-proof ourselves with any changes to this pattern.