### PR TITLE
[3.x] Add Vite 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x, latest]
+        node-version: [20.x, 22.x, 24.x, latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, latest]
+        node-version: [22.x, 24.x, latest]
 
     steps:
       - name: Checkout code

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,44 @@
 # Upgrade Guide
 
+## `2.x` to `3.x`
+
+- Adds support for Vite 8
+
+### Upgrade Path
+
+If you are using `import.meta.glob` to add static assets into your build, you will need to migrate them to the new `assets` config option, e.g.,
+
+```diff
+// file: ./resources/js/app.js
+
+import './bootstrap';
+
+- import.meta.glob([
+-     '../images/**',
+-     '../favicons/**',
+- ])
+```
+
+```diff
+// file: ./vite.config.js
+
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
++           assets: [
++               '../images/**',
++               '../favicons/**',
++           ],
+        }),
+    ],
+});
+```
+
 ## `0.x` to `1.x`
 
 - Adds support for Vite 5 and removes support for Vite 3 and 4.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.30.1",
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/picomatch": "^4.0.2",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "esbuild": "0.27.4",

--- a/package.json
+++ b/package.json
@@ -48,15 +48,15 @@
         "@types/node": "^20.19.0 || >=22.12.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
-        "esbuild": "0.25.6",
+        "esbuild": "0.27.4",
         "eslint": "^9.0.0",
         "globals": "^16.3.0",
         "typescript": "^5.0.0",
-        "vite": "^7.0.0",
+        "vite": "^8.0.0",
         "vitest": "^3.0.0"
     },
     "peerDependencies": {
-        "vite": "^7.0.0"
+        "vite": "^8.0.0"
     },
     "engines": {
         "node": "^20.19.0 || >=22.12.0"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     },
     "dependencies": {
         "picocolors": "^1.0.0",
+        "tinyglobby": "^0.2.12",
         "vite-plugin-full-reload": "^1.1.0"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,14 @@ import os from 'os'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import colors from 'picocolors'
-import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rollup, createLogger, defaultAllowedOrigins } from 'vite'
+import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rolldown, createLogger, defaultAllowedOrigins } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
 
 interface PluginConfig {
     /**
      * The path or paths of the entry points to compile.
      */
-    input: Rollup.InputOption
+    input: Rolldown.InputOption
 
     /**
      * Laravel's public directory.
@@ -37,7 +37,7 @@ interface PluginConfig {
     /**
      * The path of the SSR entry point.
      */
-    ssr?: Rollup.InputOption
+    ssr?: Rolldown.InputOption
 
     /**
      * The directory where the SSR bundle should be written.
@@ -148,8 +148,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                     manifest: userConfig.build?.manifest ?? (ssr ? false : 'manifest.json'),
                     ssrManifest: userConfig.build?.ssrManifest ?? (ssr ? 'ssr-manifest.json' : false),
                     outDir: userConfig.build?.outDir ?? resolveOutDir(pluginConfig, ssr),
-                    rollupOptions: {
-                        input: userConfig.build?.rollupOptions?.input ?? resolveInput(pluginConfig, ssr)
+                    rolldownOptions: {
+                        input: userConfig.build?.rolldownOptions?.input
+                            ?? userConfig.build?.rollupOptions?.input
+                            ?? resolveInput(pluginConfig, ssr)
                     },
                     assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
                 },
@@ -389,7 +391,7 @@ function resolveBase(config: Required<PluginConfig>, assetUrl: string): string {
 /**
  * Resolve the Vite input path from the configuration.
  */
-function resolveInput(config: Required<PluginConfig>, ssr: boolean): Rollup.InputOption|undefined {
+function resolveInput(config: Required<PluginConfig>, ssr: boolean): Rolldown.InputOption|undefined {
     if (ssr) {
         return config.ssr
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,17 @@ interface PluginConfig {
      * Transform the code while serving.
      */
     transformOnServe?: (code: string, url: DevServerUrl) => string,
+
+    /**
+     * Asset file glob patterns to include in the build.
+     *
+     * Files matching these patterns will be processed and versioned by Vite,
+     * even if they are not imported in your JavaScript. This is useful for
+     * assets referenced in Blade templates via `Vite::asset()`.
+     *
+     * @default []
+     */
+    assets?: string|string[]
 }
 
 interface RefreshConfig {
@@ -111,6 +122,7 @@ export default function laravel(config: string|string[]|PluginConfig): [LaravelP
 
     return [
         resolveLaravelPlugin(pluginConfig),
+        ...resolveAssetPlugin(pluginConfig.assets),
         ...resolveFullReloadConfig(pluginConfig) as Plugin[],
     ];
 }
@@ -378,6 +390,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         valetTls: config.valetTls ?? null,
         detectTls: config.detectTls ?? config.valetTls ?? null,
         transformOnServe: config.transformOnServe ?? ((code) => code),
+        assets: typeof config.assets === 'string' ? [config.assets] : config.assets ?? [],
     }
 }
 
@@ -408,6 +421,27 @@ function resolveOutDir(config: Required<PluginConfig>, ssr: boolean): string|und
     }
 
     return path.join(config.publicDirectory, config.buildDirectory)
+}
+
+/**
+ * Resolve the asset-emitting plugin from the configuration.
+ */
+function resolveAssetPlugin(assets: string|string[]): Plugin[] {
+    if (assets.length === 0) {
+        return []
+    }
+
+    return [{
+        name: 'laravel:assets',
+        apply: 'build',
+        buildStart() {
+            for (const file of fs.globSync(assets)) {
+                if (fs.statSync(file).isFile()) {
+                    this.emitFile({ type: 'chunk', id: file })
+                }
+            }
+        },
+    }]
 }
 
 function resolveFullReloadConfig({ refresh: config }: Required<PluginConfig>): PluginOption[]{

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { AddressInfo } from 'net'
 import os from 'os'
 import { fileURLToPath } from 'url'
 import path from 'path'
+import { globSync } from 'tinyglobby'
 import colors from 'picocolors'
 import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rolldown, createLogger, defaultAllowedOrigins } from 'vite'
 import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
@@ -435,7 +436,7 @@ function resolveAssetPlugin(assets: string|string[]): Plugin[] {
         name: 'laravel:assets',
         apply: 'build',
         buildStart() {
-            for (const file of fs.globSync(assets)) {
+            for (const file of globSync(assets)) {
                 if (fs.statSync(file).isFile()) {
                     this.emitFile({ type: 'chunk', id: file })
                 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -42,10 +42,10 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel('resources/js/app.ts')[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
-        expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
+        expect(config.build.rolldownOptions.input).toBe('resources/js/app.ts')
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
-        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/app.ts')
+        expect(ssrConfig.build.rolldownOptions.input).toBe('resources/js/app.ts')
     })
 
     it('accepts an array of inputs', () => {
@@ -55,10 +55,10 @@ describe('laravel-vite-plugin', () => {
         ])[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
-        expect(config.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
+        expect(config.build.rolldownOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
-        expect(ssrConfig.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
+        expect(ssrConfig.build.rolldownOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
     })
 
     it('accepts a full configuration', () => {
@@ -74,13 +74,13 @@ describe('laravel-vite-plugin', () => {
         expect(config.base).toBe('/other-build/')
         expect(config.build.manifest).toBe('manifest.json')
         expect(config.build.outDir).toBe('other-public/other-build')
-        expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
+        expect(config.build.rolldownOptions.input).toBe('resources/js/app.ts')
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/other-build/')
         expect(ssrConfig.build.manifest).toBe(false)
         expect(ssrConfig.build.outDir).toBe('other-ssr-output')
-        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.ts')
+        expect(ssrConfig.build.rolldownOptions.input).toBe('resources/js/ssr.ts')
     })
 
     it('accepts a single input within a full configuration', () => {
@@ -90,10 +90,10 @@ describe('laravel-vite-plugin', () => {
         })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
-        expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
+        expect(config.build.rolldownOptions.input).toBe('resources/js/app.ts')
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
-        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.ts')
+        expect(ssrConfig.build.rolldownOptions.input).toBe('resources/js/ssr.ts')
     })
 
     it('accepts an array of inputs within a full configuration', () => {
@@ -103,10 +103,10 @@ describe('laravel-vite-plugin', () => {
         })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
-        expect(config.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
+        expect(config.build.rolldownOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
-        expect(ssrConfig.build.rollupOptions.input).toEqual(['resources/js/ssr.ts', 'resources/js/other.js'])
+        expect(ssrConfig.build.rolldownOptions.input).toEqual(['resources/js/ssr.ts', 'resources/js/other.js'])
     })
 
     it('accepts an input object within a full configuration', () => {
@@ -116,10 +116,10 @@ describe('laravel-vite-plugin', () => {
         })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
-        expect(config.build.rollupOptions.input).toEqual({ app: 'resources/js/entrypoint-browser.js' })
+        expect(config.build.rolldownOptions.input).toEqual({ app: 'resources/js/entrypoint-browser.js' })
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
-        expect(ssrConfig.build.rollupOptions.input).toEqual({ ssr: 'resources/js/entrypoint-ssr.js' })
+        expect(ssrConfig.build.rolldownOptions.input).toEqual({ ssr: 'resources/js/entrypoint-ssr.js' })
     })
 
     it('respects the users build.manifest config option', () => {
@@ -168,13 +168,13 @@ describe('laravel-vite-plugin', () => {
         expect(config.base).toBe('/build/')
         expect(config.build.manifest).toBe('manifest.json')
         expect(config.build.outDir).toBe('public/build')
-        expect(config.build.rollupOptions.input).toBe('resources/js/app.js')
+        expect(config.build.rolldownOptions.input).toBe('resources/js/app.js')
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.base).toBe('/build/')
         expect(ssrConfig.build.manifest).toBe(false)
         expect(ssrConfig.build.outDir).toBe('bootstrap/ssr')
-        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
+        expect(ssrConfig.build.rolldownOptions.input).toBe('resources/js/ssr.js')
     })
 
     it('uses the default entry point when ssr entry point is not provided', () => {
@@ -182,7 +182,7 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel('resources/js/ssr.js')[0]
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
-        expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
+        expect(ssrConfig.build.rolldownOptions.input).toBe('resources/js/ssr.js')
     })
 
     it('prefixes the base with ASSET_URL in production mode', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -526,6 +526,42 @@ describe('laravel-vite-plugin', () => {
 
         expect(resolvedConfig.server.cors).toBe(true)
     })
+
+    it('does not include assets plugin when no assets are configured', () => {
+        const plugins = laravel('resources/js/app.ts')
+
+        expect(plugins.find(plugin => plugin.name === 'laravel:assets')).toBeUndefined()
+    })
+
+    it('emits assets as chunks when assets is a string', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.ts',
+            assets: 'tests/__data__/*.ts',
+        })
+
+        const assetsPlugin = plugins.find(plugin => plugin.name === 'laravel:assets')!
+        const emitFile = vi.fn()
+
+        assetsPlugin.buildStart!.call({ emitFile })
+
+        expect(emitFile).toHaveBeenCalledWith({ type: 'chunk', id: expect.stringContaining('dummy.ts') })
+    })
+
+    it('emits assets as chunks when assets is an array', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.ts',
+            assets: ['tests/__data__/*.ts'],
+        })
+
+        const assetsPlugin = plugins.find(plugin => plugin.name === 'laravel:assets')!
+        const emitFile = vi.fn()
+
+        assetsPlugin.buildStart!.call({ emitFile })
+
+        expect(emitFile).toHaveBeenCalledWith({ type: 'chunk', id: expect.stringContaining('dummy.ts') })
+    })
+
+
 })
 
 describe('inertia-helpers', () => {


### PR DESCRIPTION
Replaces the great work done in https://github.com/laravel/vite-plugin/pull/341 with the minimum changes required to add Vite 8 support.

We have found a breaking change we are investigating before merging this one.