### PR TITLE
Exclude default Laravel directories from dev server file watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     },
     "dependencies": {
         "picocolors": "^1.0.0",
+        "picomatch": "^4.0.0",
         "tinyglobby": "^0.2.12",
         "vite-plugin-full-reload": "^1.1.0"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,21 @@ export const refreshPaths = [
     'routes/**',
 ].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
 
+/**
+ * The project-root directories excluded from Vite's dev-mode file watcher by default.
+ *
+ * Watching these directories can trigger unnecessary full page reloads and, on Linux,
+ * contributes to inotify watch exhaustion. They are matched only at the project root,
+ * so sibling directories such as `public/vendor` remain watched.
+ */
+export const watchIgnoredDirectories = [
+    'bootstrap',
+    'database',
+    'storage',
+    'tests',
+    'vendor',
+]
+
 const logger = createLogger('info', {
     prefix: '[laravel-vite-plugin]'
 })
@@ -154,6 +169,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
 
             ensureCommandShouldRunInEnvironment(command, env)
 
+            const watchIgnored = command === 'serve'
+                ? resolveWatchIgnored(pluginConfig, userConfig)
+                : undefined
+
             return {
                 base: userConfig.base ?? (command === 'build' ? resolveBase(pluginConfig, assetUrl) : ''),
                 publicDir: userConfig.publicDir ?? false,
@@ -189,6 +208,12 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                             ...(userConfig.server?.hmr === true ? {} : userConfig.server?.hmr),
                         },
                         https: userConfig.server?.https ?? serverConfig.https,
+                    } : undefined),
+                    ...(watchIgnored ? {
+                        watch: {
+                            ...userConfig.server?.watch,
+                            ignored: watchIgnored,
+                        },
                     } : undefined),
                 },
                 resolve: {
@@ -422,6 +447,87 @@ function resolveOutDir(config: Required<PluginConfig>, ssr: boolean): string|und
     }
 
     return path.join(config.publicDirectory, config.buildDirectory)
+}
+
+/**
+ * Resolve the file watcher `ignored` option.
+ *
+ * Falls back to the user-provided value when present. Otherwise returns a
+ * matcher that ignores Laravel directories that typically change frequently
+ * during development but should never trigger a page reload — while leaving
+ * any directory the user has configured for refresh fully watched.
+ */
+function resolveWatchIgnored(
+    pluginConfig: Required<PluginConfig>,
+    userConfig: UserConfig,
+): ((file: string) => boolean)|undefined {
+    const userIgnored = userConfig.server?.watch?.ignored
+    if (typeof userIgnored !== 'undefined') {
+        return undefined
+    }
+
+    const root = path.resolve(userConfig.root ?? process.cwd())
+    const refreshTopDirectories = collectRefreshTopDirectories(pluginConfig.refresh)
+    const ignoredDirectories = watchIgnoredDirectories.filter(dir => ! refreshTopDirectories.has(dir))
+
+    if (ignoredDirectories.length === 0) {
+        return undefined
+    }
+
+    return (file: string): boolean => {
+        const absolutePath = path.resolve(file)
+
+        if (absolutePath === root || ! absolutePath.startsWith(root + path.sep)) {
+            return false
+        }
+
+        const relativePath = path.relative(root, absolutePath).split(path.sep).join('/')
+        const topDirectory = relativePath.split('/')[0]
+
+        return ignoredDirectories.includes(topDirectory)
+    }
+}
+
+/**
+ * Collect the top-level directory names that the user is refreshing on, so
+ * they can be excluded from the default watch-ignore list.
+ */
+function collectRefreshTopDirectories(refresh: Required<PluginConfig>['refresh']): Set<string> {
+    const directories = new Set<string>()
+
+    if (typeof refresh === 'boolean') {
+        if (refresh) {
+            for (const p of refreshPaths) {
+                addRefreshTopDirectory(directories, p)
+            }
+        }
+
+        return directories
+    }
+
+    const configs = Array.isArray(refresh) ? refresh : [refresh]
+
+    for (const entry of configs) {
+        if (typeof entry === 'string') {
+            addRefreshTopDirectory(directories, entry)
+            continue
+        }
+
+        for (const p of entry.paths) {
+            addRefreshTopDirectory(directories, p)
+        }
+    }
+
+    return directories
+}
+
+function addRefreshTopDirectory(target: Set<string>, refreshPath: string): void {
+    const normalized = refreshPath.replace(/^(\.?\/)+/, '')
+    const topDirectory = normalized.split(/[/\\]/)[0]
+
+    if (topDirectory && ! topDirectory.includes('*')) {
+        target.add(topDirectory)
+    }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -488,9 +488,14 @@ function resolveWatchIgnored(
  * refresh plugin matches them, so anything it will refresh remains watched.
  */
 function resolveRefreshMatcher(refresh: Required<PluginConfig>['refresh']): (file: string) => boolean {
-    return picomatch(resolveRefreshConfigs(refresh).flatMap(
-        ({ paths, config }) => normalizePaths(config?.root ?? process.cwd(), paths)
-    ))
+    if (typeof refresh === 'boolean') {
+        return picomatch([])
+    }
+
+    const configs = (Array.isArray(refresh) ? refresh : [refresh])
+        .map(entry => typeof entry === 'string' ? { paths: [entry] } : entry)
+
+    return picomatch(configs.flatMap(({ paths, config }) => normalizePaths(config?.root ?? process.cwd(), paths)))
 }
 
 /**
@@ -521,22 +526,7 @@ function resolveAssetPlugin(assets: string|string[]): Plugin[] {
     }]
 }
 
-function resolveFullReloadConfig({ refresh }: Required<PluginConfig>): PluginOption[]{
-    return resolveRefreshConfigs(refresh).flatMap(c => {
-        const plugin = fullReload(c.paths, c.config)
-
-        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-        /** @ts-ignore */
-        plugin.__laravel_plugin_config = c
-
-        return plugin
-    })
-}
-
-/**
- * Resolve the refresh configuration to its normalised form.
- */
-function resolveRefreshConfigs(config: Required<PluginConfig>['refresh']): RefreshConfig[] {
+function resolveFullReloadConfig({ refresh: config }: Required<PluginConfig>): PluginOption[]{
     if (typeof config === 'boolean') {
         return [];
     }
@@ -553,7 +543,15 @@ function resolveRefreshConfigs(config: Required<PluginConfig>['refresh']): Refre
         config = [{ paths: config }] as RefreshConfig[]
     }
 
-    return config as RefreshConfig[]
+    return (config as RefreshConfig[]).flatMap(c => {
+        const plugin = fullReload(c.paths, c.config)
+
+        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+        /** @ts-ignore */
+        plugin.__laravel_plugin_config = c
+
+        return plugin
+    })
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,8 @@ interface LaravelPlugin extends Plugin {
 
 type DevServerUrl = `${'http'|'https'}://${string}:${number}`
 
+type WatchIgnored = NonNullable<NonNullable<UserConfig['server']>['watch']>['ignored']
+
 let exitHandlersBound = false
 
 export const refreshPaths = [
@@ -109,16 +111,11 @@ export const refreshPaths = [
     'routes/**',
 ].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
 
-/**
- * The project-root directories excluded from Vite's dev-mode file watcher by default.
- *
- * Watching these directories can trigger unnecessary full page reloads and, on Linux,
- * contributes to inotify watch exhaustion. They are matched only at the project root,
- * so sibling directories such as `public/vendor` remain watched.
- */
-export const watchIgnoredDirectories = [
+export const ignorePathsWhenWatching = [
+    '.phpunit.cache',
     'bootstrap',
     'database',
+    'public/storage',
     'storage',
     'tests',
     'vendor',
@@ -209,7 +206,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
                         },
                         https: userConfig.server?.https ?? serverConfig.https,
                     } : undefined),
-                    ...(watchIgnored ? {
+                    ...(typeof watchIgnored !== 'undefined' ? {
                         watch: {
                             ...userConfig.server?.watch,
                             ignored: watchIgnored,
@@ -452,82 +449,100 @@ function resolveOutDir(config: Required<PluginConfig>, ssr: boolean): string|und
 /**
  * Resolve the file watcher `ignored` option.
  *
- * Falls back to the user-provided value when present. Otherwise returns a
- * matcher that ignores Laravel directories that typically change frequently
- * during development but should never trigger a page reload — while leaving
- * any directory the user has configured for refresh fully watched.
+ * Respects the user-provided value when present. Otherwise returns a matcher
+ * for the default ignored paths — while leaving any path the user has
+ * configured for refresh watched.
  */
 function resolveWatchIgnored(
     pluginConfig: Required<PluginConfig>,
     userConfig: UserConfig,
-): ((file: string) => boolean)|undefined {
-    const userIgnored = userConfig.server?.watch?.ignored
-    if (typeof userIgnored !== 'undefined') {
+): WatchIgnored {
+    if (userConfig.server?.watch === null) {
         return undefined
+    }
+
+    const userIgnored = userConfig.server?.watch?.ignored
+
+    if (typeof userIgnored !== 'undefined') {
+        return userIgnored
     }
 
     const root = path.resolve(userConfig.root ?? process.cwd())
-    const refreshTopDirectories = collectRefreshTopDirectories(pluginConfig.refresh)
-    const ignoredDirectories = watchIgnoredDirectories.filter(dir => ! refreshTopDirectories.has(dir))
 
-    if (ignoredDirectories.length === 0) {
-        return undefined
-    }
+    // The paths are resolved up front, as the matcher is called for every file
+    // and directory the watcher encounters.
+    const ignoredPaths = resolveAbsolutePaths(root, ignorePathsWhenWatching)
+    const refreshedPaths = resolveAbsolutePaths(root, resolveRefreshedPaths(pluginConfig.refresh))
 
     return (file: string): boolean => {
         const absolutePath = path.resolve(file)
 
-        if (absolutePath === root || ! absolutePath.startsWith(root + path.sep)) {
-            return false
-        }
-
-        const relativePath = path.relative(root, absolutePath).split(path.sep).join('/')
-        const topDirectory = relativePath.split('/')[0]
-
-        return ignoredDirectories.includes(topDirectory)
+        // The refreshed paths are matched in both directions, as ancestors must
+        // remain watched for the watcher to descend into a refreshed path.
+        return ignoredPaths.some(ignoredPath => pathIsWithin(absolutePath, ignoredPath))
+            && ! refreshedPaths.some(refreshedPath => pathsOverlap(absolutePath, refreshedPath))
     }
 }
 
 /**
- * Collect the top-level directory names that the user is refreshing on, so
- * they can be excluded from the default watch-ignore list.
+ * Resolve the given root-relative paths against the root, discarding any that
+ * are the root itself or fall outside of it.
  */
-function collectRefreshTopDirectories(refresh: Required<PluginConfig>['refresh']): Set<string> {
-    const directories = new Set<string>()
+function resolveAbsolutePaths(root: string, paths: string[]): string[] {
+    return paths
+        .map(watchPath => path.resolve(root, normalizeWatchPath(watchPath)))
+        .filter(absolutePath => absolutePath !== root && pathIsWithin(absolutePath, root))
+}
+
+/**
+ * Resolve the paths the user is refreshing on, so they can be excluded from
+ * the watch-ignore list.
+ */
+function resolveRefreshedPaths(refresh: Required<PluginConfig>['refresh']): string[] {
+    const paths: string[] = []
 
     if (typeof refresh === 'boolean') {
         if (refresh) {
-            for (const p of refreshPaths) {
-                addRefreshTopDirectory(directories, p)
-            }
+            paths.push(...refreshPaths)
         }
-
-        return directories
-    }
-
-    const configs = Array.isArray(refresh) ? refresh : [refresh]
-
-    for (const entry of configs) {
-        if (typeof entry === 'string') {
-            addRefreshTopDirectory(directories, entry)
-            continue
-        }
-
-        for (const p of entry.paths) {
-            addRefreshTopDirectory(directories, p)
+    } else {
+        for (const entry of Array.isArray(refresh) ? refresh : [refresh]) {
+            paths.push(...(typeof entry === 'string' ? [entry] : entry.paths))
         }
     }
 
-    return directories
+    return paths.map(stripGlob)
 }
 
-function addRefreshTopDirectory(target: Set<string>, refreshPath: string): void {
-    const normalized = refreshPath.replace(/^(\.?\/)+/, '')
-    const topDirectory = normalized.split(/[/\\]/)[0]
+/**
+ * Normalise a watch path to a root-relative path with forward slashes.
+ */
+function normalizeWatchPath(watchPath: string): string {
+    return watchPath.replace(/\\/g, '/').replace(/^(\.?\/)+/, '').replace(/\/+$/, '')
+}
 
-    if (topDirectory && ! topDirectory.includes('*')) {
-        target.add(topDirectory)
-    }
+/**
+ * Reduce a glob to the static path leading up to the first pattern segment.
+ */
+function stripGlob(pattern: string): string {
+    const segments = normalizeWatchPath(pattern).split('/')
+    const globIndex = segments.findIndex(segment => /[*?[{]/.test(segment))
+
+    return (globIndex === -1 ? segments : segments.slice(0, globIndex)).join('/')
+}
+
+/**
+ * Determine whether the given path is, or is contained within, the other path.
+ */
+function pathIsWithin(subject: string, parent: string): boolean {
+    return subject === parent || subject.startsWith(parent + path.sep)
+}
+
+/**
+ * Determine whether either path is, or is contained within, the other.
+ */
+function pathsOverlap(a: string, b: string): boolean {
+    return pathIsWithin(a, b) || pathIsWithin(b, a)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,17 +444,7 @@ function resolveOutDir(config: Required<PluginConfig>, ssr: boolean): string|und
     return path.join(config.publicDirectory, config.buildDirectory)
 }
 
-/**
- * Resolve the file watcher `ignored` option.
- *
- * Respects the user-provided value when present. Otherwise returns a matcher
- * for the default ignored paths — while leaving any path the user has
- * configured for refresh watched.
- */
-function resolveWatchIgnored(
-    pluginConfig: Required<PluginConfig>,
-    userConfig: UserConfig,
-): NonNullable<NonNullable<UserConfig['server']>['watch']>['ignored'] {
+function resolveWatchIgnored(pluginConfig: Required<PluginConfig>, userConfig: UserConfig): NonNullable<NonNullable<UserConfig['server']>['watch']>['ignored'] {
     if (userConfig.server?.watch === null) {
         return undefined
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -459,16 +459,16 @@ function resolveWatchIgnored(pluginConfig: Required<PluginConfig>, userConfig: U
 
     return (file: string): boolean => {
         if (! shouldIgnorePath(file)) {
-            console.debug(`Path is being watched: ${file}`)
+            // console.debug(`Path is being watched: ${file}`)
 
             return false
         }
 
-        console.debug(`Path configured to be ignored: ${file}`)
+        // console.debug(`Path configured to be ignored: ${file}`)
 
         const ignore = ! pathConfiguredToTriggerRefresh(normalizePath(file))
 
-        console.debug(`Path is ${ignore ? 'ignored' : 'not ignored because it is configured to refresh'}: ${file}`)
+        // console.debug(`Path is ${ignore ? 'ignored' : 'not ignored because it is configured to refresh'}: ${file}`)
 
         return ignore
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,16 @@ export const refreshPaths = [
     'routes/**',
 ].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
 
+export const ignorePathsWhenWatching = [
+    '.phpunit.cache/',
+    'bootstrap/',
+    'database/',
+    'public/storage/',
+    'storage/',
+    'tests/',
+    'vendor/',
+].filter(path => fs.existsSync(path))
+
 const logger = createLogger('info', {
     prefix: '[laravel-vite-plugin]'
 })
@@ -459,15 +469,7 @@ function resolveWatchIgnored(
 
     // The paths are resolved up front, as the matcher is called for every file
     // and directory the watcher encounters.
-    const ignoredPaths = resolveAbsolutePaths(root, [
-        '.phpunit.cache',
-        'bootstrap',
-        'database',
-        'public/storage',
-        'storage',
-        'tests',
-        'vendor',
-    ])
+    const ignoredPaths = resolveAbsolutePaths(root, ignorePathsWhenWatching)
     const refreshedPaths = resolveAbsolutePaths(root, resolveRefreshedPaths(pluginConfig.refresh))
 
     return (file: string): boolean => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,14 +457,28 @@ function resolveWatchIgnored(pluginConfig: Required<PluginConfig>, userConfig: U
 
     const pathConfiguredToTriggerRefresh = resolveRefreshMatcher(pluginConfig.refresh)
 
+    console.debug(`Default ignored paths when watching`, ignorePathsWhenWatching)
+
     return (file: string): boolean => {
+        console.debug(`Checking if path should be ignored: ${file}`)
+
         const absolutePath = path.resolve(file)
 
-        if (! ignorePathsWhenWatching.some(ignoredPath => pathMatches(absolutePath, ignoredPath))) {
+        console.log(`Absolute path resolved to: ${absolutePath}`)
+
+        if (! shouldIgnorePath(absolutePath)) {
+            console.debug(`Path is being watched: ${absolutePath}`)
+
             return false
         }
 
-        return ! pathConfiguredToTriggerRefresh(normalizePath(absolutePath))
+        console.debug(`Path configured to be ignored: ${absolutePath}`)
+
+        const ignore = ! pathConfiguredToTriggerRefresh(normalizePath(absolutePath))
+
+        console.debug(`Path is ${ignore ? 'ignored' : 'not ignored because it is configured to refresh'}: ${absolutePath}`)
+
+        return ignore
     }
 }
 
@@ -480,10 +494,10 @@ function resolveRefreshMatcher(refresh: Required<PluginConfig>['refresh']): (fil
 }
 
 /**
- * Determine whether the given path is, or is contained within, the other path.
+ * Determine whether the given path is, or is contained within, an ignored path.
  */
-function pathMatches(subject: string, parent: string): boolean {
-    return subject.startsWith(parent + path.sep) || subject === parent
+function shouldIgnorePath(absolutePath: string): boolean {
+    return ignorePathsWhenWatching.some(ignoredPath => absolutePath.startsWith(ignoredPath + path.sep) || absolutePath === ignoredPath)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,13 @@ interface PluginConfig {
     refresh?: boolean|string|string[]|RefreshConfig|RefreshConfig[]
 
     /**
+     * The paths to exclude from the dev server's file watcher, relative to the project root.
+     *
+     * @default defaultIgnorePathsWhenWatching
+     */
+    ignorePathsWhenWatching?: string[]
+
+    /**
      * Utilise the Herd or Valet TLS certificates.
      *
      * @default null
@@ -110,7 +117,7 @@ export const refreshPaths = [
     'routes/**',
 ].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
 
-export const ignorePathsWhenWatching = [
+export const defaultIgnorePathsWhenWatching = [
     '.phpunit.cache/',
     'bootstrap/',
     'database/',
@@ -118,7 +125,7 @@ export const ignorePathsWhenWatching = [
     'storage/',
     'tests/',
     'vendor/',
-].filter(path => fs.existsSync(path)).map(directory => path.resolve(directory))
+].filter(directory => fs.existsSync(directory))
 
 const logger = createLogger('info', {
     prefix: '[laravel-vite-plugin]'
@@ -407,6 +414,7 @@ function resolvePluginConfig(config: string|string[]|PluginConfig): Required<Plu
         ssr: config.ssr ?? config.input,
         ssrOutputDirectory: config.ssrOutputDirectory ?? 'bootstrap/ssr',
         refresh: config.refresh ?? false,
+        ignorePathsWhenWatching: config.ignorePathsWhenWatching ?? defaultIgnorePathsWhenWatching,
         hotFile: config.hotFile ?? path.join((config.publicDirectory ?? 'public'), 'hot'),
         valetTls: config.valetTls ?? null,
         detectTls: config.detectTls ?? config.valetTls ?? null,
@@ -456,9 +464,10 @@ function resolveWatchIgnored(pluginConfig: Required<PluginConfig>, userConfig: U
     }
 
     const pathConfiguredToTriggerRefresh = resolveRefreshMatcher(pluginConfig.refresh)
+    const ignoredPaths = resolveIgnoredWatchPaths(pluginConfig.ignorePathsWhenWatching)
 
     return (file: string): boolean => {
-        if (! shouldIgnorePath(file)) {
+        if (! shouldIgnorePath(file, ignoredPaths)) {
             // console.debug(`Path is being watched: ${file}`)
 
             return false
@@ -486,10 +495,17 @@ function resolveRefreshMatcher(refresh: Required<PluginConfig>['refresh']): (fil
 }
 
 /**
+ * Resolve the configured ignore paths, relative to the project root, to absolute paths.
+ */
+function resolveIgnoredWatchPaths(paths: string[]): string[] {
+    return paths.map(directory => path.resolve(directory))
+}
+
+/**
  * Determine whether the given path is, or is contained within, an ignored path.
  */
-function shouldIgnorePath(absolutePath: string): boolean {
-    return ignorePathsWhenWatching.some(ignoredPath => absolutePath.startsWith(ignoredPath + path.sep) || absolutePath === ignoredPath)
+function shouldIgnorePath(absolutePath: string, ignoredPaths: string[]): boolean {
+    return ignoredPaths.some(ignoredPath => absolutePath.startsWith(ignoredPath + path.sep) || absolutePath === ignoredPath)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,12 +162,11 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const serverConfig = command === 'serve'
                 ? (resolveDevelopmentEnvironmentServerConfig(pluginConfig.detectTls) ?? resolveEnvironmentServerConfig(env))
                 : undefined
-
-            ensureCommandShouldRunInEnvironment(command, env)
-
             const watchIgnored = command === 'serve'
                 ? resolveWatchIgnored(pluginConfig, userConfig)
                 : undefined
+
+            ensureCommandShouldRunInEnvironment(command, env)
 
             return {
                 base: userConfig.base ?? (command === 'build' ? resolveBase(pluginConfig, assetUrl) : ''),

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export const ignorePathsWhenWatching = [
     'storage/',
     'tests/',
     'vendor/',
-].filter(path => fs.existsSync(path))
+].filter(path => fs.existsSync(path)).map(directory => path.resolve(directory))
 
 const logger = createLogger('info', {
     prefix: '[laravel-vite-plugin]'
@@ -466,27 +466,19 @@ function resolveWatchIgnored(
         return userIgnored
     }
 
-    // The paths and matcher are resolved up front, as the matcher is called for
-    // every file and directory the watcher encounters.
-    const root = path.resolve(userConfig.root ?? process.cwd())
-    const ignoredPaths = ignorePathsWhenWatching.map(ignoredPath => path.resolve(root, ignoredPath))
-    const willRefresh = resolveRefreshMatcher(pluginConfig.refresh)
+    const pathConfiguredToTriggerRefresh = resolveRefreshMatcher(pluginConfig.refresh)
 
     return (file: string): boolean => {
         const absolutePath = path.resolve(file)
 
-        if (! ignoredPaths.some(ignoredPath => pathIsWithin(absolutePath, ignoredPath))) {
+        if (! ignorePathsWhenWatching.some(ignoredPath => pathMatches(absolutePath, ignoredPath))) {
             return false
         }
 
-        return ! willRefresh(normalizePath(absolutePath))
+        return ! pathConfiguredToTriggerRefresh(normalizePath(absolutePath))
     }
 }
 
-/**
- * Resolve a matcher for the paths that trigger a refresh, mirroring the way the
- * refresh plugin matches them, so anything it will refresh remains watched.
- */
 function resolveRefreshMatcher(refresh: Required<PluginConfig>['refresh']): (file: string) => boolean {
     if (typeof refresh === 'boolean') {
         return picomatch([])
@@ -501,8 +493,8 @@ function resolveRefreshMatcher(refresh: Required<PluginConfig>['refresh']): (fil
 /**
  * Determine whether the given path is, or is contained within, the other path.
  */
-function pathIsWithin(subject: string, parent: string): boolean {
-    return subject === parent || subject.startsWith(parent + path.sep)
+function pathMatches(subject: string, parent: string): boolean {
+    return subject.startsWith(parent + path.sep) || subject === parent
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,6 @@ interface LaravelPlugin extends Plugin {
 
 type DevServerUrl = `${'http'|'https'}://${string}:${number}`
 
-type WatchIgnored = NonNullable<NonNullable<UserConfig['server']>['watch']>['ignored']
-
 let exitHandlersBound = false
 
 export const refreshPaths = [
@@ -113,12 +111,12 @@ export const refreshPaths = [
 
 export const ignorePathsWhenWatching = [
     '.phpunit.cache',
-    'bootstrap',
-    'database',
-    'public/storage',
-    'storage',
-    'tests',
-    'vendor',
+    'bootstrap/**',
+    'database/**',
+    'public/storage/**',
+    'storage/**',
+    'tests/**',
+    'vendor/**',
 ]
 
 const logger = createLogger('info', {
@@ -456,7 +454,7 @@ function resolveOutDir(config: Required<PluginConfig>, ssr: boolean): string|und
 function resolveWatchIgnored(
     pluginConfig: Required<PluginConfig>,
     userConfig: UserConfig,
-): WatchIgnored {
+): NonNullable<NonNullable<UserConfig['server']>['watch']>['ignored'] {
     if (userConfig.server?.watch === null) {
         return undefined
     }
@@ -487,10 +485,14 @@ function resolveWatchIgnored(
 /**
  * Resolve the given root-relative paths against the root, discarding any that
  * are the root itself or fall outside of it.
+ *
+ * A path is matched against the directory it points at and everything within
+ * it, so any pattern segments are reduced to the static path leading up to
+ * them, e.g. `vendor/**` matches the `vendor` directory and its contents.
  */
 function resolveAbsolutePaths(root: string, paths: string[]): string[] {
     return paths
-        .map(watchPath => path.resolve(root, normalizeWatchPath(watchPath)))
+        .map(watchPath => path.resolve(root, stripGlob(watchPath)))
         .filter(absolutePath => absolutePath !== root && pathIsWithin(absolutePath, root))
 }
 
@@ -511,7 +513,7 @@ function resolveRefreshedPaths(refresh: Required<PluginConfig>['refresh']): stri
         }
     }
 
-    return paths.map(stripGlob)
+    return paths
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,26 +457,18 @@ function resolveWatchIgnored(pluginConfig: Required<PluginConfig>, userConfig: U
 
     const pathConfiguredToTriggerRefresh = resolveRefreshMatcher(pluginConfig.refresh)
 
-    console.debug(`Default ignored paths when watching`, ignorePathsWhenWatching)
-
     return (file: string): boolean => {
-        console.debug(`Checking if path should be ignored: ${file}`)
-
-        const absolutePath = path.resolve(file)
-
-        console.log(`Absolute path resolved to: ${absolutePath}`)
-
-        if (! shouldIgnorePath(absolutePath)) {
-            console.debug(`Path is being watched: ${absolutePath}`)
+        if (! shouldIgnorePath(file)) {
+            console.debug(`Path is being watched: ${file}`)
 
             return false
         }
 
-        console.debug(`Path configured to be ignored: ${absolutePath}`)
+        console.debug(`Path configured to be ignored: ${file}`)
 
-        const ignore = ! pathConfiguredToTriggerRefresh(normalizePath(absolutePath))
+        const ignore = ! pathConfiguredToTriggerRefresh(normalizePath(file))
 
-        console.debug(`Path is ${ignore ? 'ignored' : 'not ignored because it is configured to refresh'}: ${absolutePath}`)
+        console.debug(`Path is ${ignore ? 'ignored' : 'not ignored because it is configured to refresh'}: ${file}`)
 
         return ignore
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,16 +109,6 @@ export const refreshPaths = [
     'routes/**',
 ].filter(path => fs.existsSync(path.replace(/\*\*$/, '')))
 
-export const ignorePathsWhenWatching = [
-    '.phpunit.cache',
-    'bootstrap/**',
-    'database/**',
-    'public/storage/**',
-    'storage/**',
-    'tests/**',
-    'vendor/**',
-]
-
 const logger = createLogger('info', {
     prefix: '[laravel-vite-plugin]'
 })
@@ -469,7 +459,15 @@ function resolveWatchIgnored(
 
     // The paths are resolved up front, as the matcher is called for every file
     // and directory the watcher encounters.
-    const ignoredPaths = resolveAbsolutePaths(root, ignorePathsWhenWatching)
+    const ignoredPaths = resolveAbsolutePaths(root, [
+        '.phpunit.cache',
+        'bootstrap',
+        'database',
+        'public/storage',
+        'storage',
+        'tests',
+        'vendor',
+    ])
     const refreshedPaths = resolveAbsolutePaths(root, resolveRefreshedPaths(pluginConfig.refresh))
 
     return (file: string): boolean => {
@@ -485,14 +483,10 @@ function resolveWatchIgnored(
 /**
  * Resolve the given root-relative paths against the root, discarding any that
  * are the root itself or fall outside of it.
- *
- * A path is matched against the directory it points at and everything within
- * it, so any pattern segments are reduced to the static path leading up to
- * them, e.g. `vendor/**` matches the `vendor` directory and its contents.
  */
 function resolveAbsolutePaths(root: string, paths: string[]): string[] {
     return paths
-        .map(watchPath => path.resolve(root, stripGlob(watchPath)))
+        .map(watchPath => path.resolve(root, watchPath))
         .filter(absolutePath => absolutePath !== root && pathIsWithin(absolutePath, root))
 }
 
@@ -513,21 +507,14 @@ function resolveRefreshedPaths(refresh: Required<PluginConfig>['refresh']): stri
         }
     }
 
-    return paths
+    return paths.map(stripGlob)
 }
 
 /**
- * Normalise a watch path to a root-relative path with forward slashes.
- */
-function normalizeWatchPath(watchPath: string): string {
-    return watchPath.replace(/\\/g, '/').replace(/^(\.?\/)+/, '').replace(/\/+$/, '')
-}
-
-/**
- * Reduce a glob to the static path leading up to the first pattern segment.
+ * Reduce a refresh glob to the static path leading up to its first pattern segment.
  */
 function stripGlob(pattern: string): string {
-    const segments = normalizeWatchPath(pattern).split('/')
+    const segments = pattern.replace(/\\/g, '/').replace(/^(\.?\/)+/, '').split('/')
     const globIndex = segments.findIndex(segment => /[*?[{]/.test(segment))
 
     return (globIndex === -1 ? segments : segments.slice(0, globIndex)).join('/')

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,9 @@ import { fileURLToPath } from 'url'
 import path from 'path'
 import { globSync } from 'tinyglobby'
 import colors from 'picocolors'
-import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rolldown, createLogger, defaultAllowedOrigins } from 'vite'
-import fullReload, { Config as FullReloadConfig } from 'vite-plugin-full-reload'
+import picomatch from 'picomatch'
+import { Plugin, loadEnv, UserConfig, ConfigEnv, ResolvedConfig, SSROptions, PluginOption, Rolldown, createLogger, defaultAllowedOrigins, normalizePath } from 'vite'
+import fullReload, { Config as FullReloadConfig, normalizePaths } from 'vite-plugin-full-reload'
 
 interface PluginConfig {
     /**
@@ -465,61 +466,31 @@ function resolveWatchIgnored(
         return userIgnored
     }
 
+    // The paths and matcher are resolved up front, as the matcher is called for
+    // every file and directory the watcher encounters.
     const root = path.resolve(userConfig.root ?? process.cwd())
-
-    // The paths are resolved up front, as the matcher is called for every file
-    // and directory the watcher encounters.
-    const ignoredPaths = resolveAbsolutePaths(root, ignorePathsWhenWatching)
-    const refreshedPaths = resolveAbsolutePaths(root, resolveRefreshedPaths(pluginConfig.refresh))
+    const ignoredPaths = ignorePathsWhenWatching.map(ignoredPath => path.resolve(root, ignoredPath))
+    const willRefresh = resolveRefreshMatcher(pluginConfig.refresh)
 
     return (file: string): boolean => {
         const absolutePath = path.resolve(file)
 
-        // The refreshed paths are matched in both directions, as ancestors must
-        // remain watched for the watcher to descend into a refreshed path.
-        return ignoredPaths.some(ignoredPath => pathIsWithin(absolutePath, ignoredPath))
-            && ! refreshedPaths.some(refreshedPath => pathsOverlap(absolutePath, refreshedPath))
+        if (! ignoredPaths.some(ignoredPath => pathIsWithin(absolutePath, ignoredPath))) {
+            return false
+        }
+
+        return ! willRefresh(normalizePath(absolutePath))
     }
 }
 
 /**
- * Resolve the given root-relative paths against the root, discarding any that
- * are the root itself or fall outside of it.
+ * Resolve a matcher for the paths that trigger a refresh, mirroring the way the
+ * refresh plugin matches them, so anything it will refresh remains watched.
  */
-function resolveAbsolutePaths(root: string, paths: string[]): string[] {
-    return paths
-        .map(watchPath => path.resolve(root, watchPath))
-        .filter(absolutePath => absolutePath !== root && pathIsWithin(absolutePath, root))
-}
-
-/**
- * Resolve the paths the user is refreshing on, so they can be excluded from
- * the watch-ignore list.
- */
-function resolveRefreshedPaths(refresh: Required<PluginConfig>['refresh']): string[] {
-    const paths: string[] = []
-
-    if (typeof refresh === 'boolean') {
-        if (refresh) {
-            paths.push(...refreshPaths)
-        }
-    } else {
-        for (const entry of Array.isArray(refresh) ? refresh : [refresh]) {
-            paths.push(...(typeof entry === 'string' ? [entry] : entry.paths))
-        }
-    }
-
-    return paths.map(stripGlob)
-}
-
-/**
- * Reduce a refresh glob to the static path leading up to its first pattern segment.
- */
-function stripGlob(pattern: string): string {
-    const segments = pattern.replace(/\\/g, '/').replace(/^(\.?\/)+/, '').split('/')
-    const globIndex = segments.findIndex(segment => /[*?[{]/.test(segment))
-
-    return (globIndex === -1 ? segments : segments.slice(0, globIndex)).join('/')
+function resolveRefreshMatcher(refresh: Required<PluginConfig>['refresh']): (file: string) => boolean {
+    return picomatch(resolveRefreshConfigs(refresh).flatMap(
+        ({ paths, config }) => normalizePaths(config?.root ?? process.cwd(), paths)
+    ))
 }
 
 /**
@@ -527,13 +498,6 @@ function stripGlob(pattern: string): string {
  */
 function pathIsWithin(subject: string, parent: string): boolean {
     return subject === parent || subject.startsWith(parent + path.sep)
-}
-
-/**
- * Determine whether either path is, or is contained within, the other.
- */
-function pathsOverlap(a: string, b: string): boolean {
-    return pathIsWithin(a, b) || pathIsWithin(b, a)
 }
 
 /**
@@ -557,7 +521,22 @@ function resolveAssetPlugin(assets: string|string[]): Plugin[] {
     }]
 }
 
-function resolveFullReloadConfig({ refresh: config }: Required<PluginConfig>): PluginOption[]{
+function resolveFullReloadConfig({ refresh }: Required<PluginConfig>): PluginOption[]{
+    return resolveRefreshConfigs(refresh).flatMap(c => {
+        const plugin = fullReload(c.paths, c.config)
+
+        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+        /** @ts-ignore */
+        plugin.__laravel_plugin_config = c
+
+        return plugin
+    })
+}
+
+/**
+ * Resolve the refresh configuration to its normalised form.
+ */
+function resolveRefreshConfigs(config: Required<PluginConfig>['refresh']): RefreshConfig[] {
     if (typeof config === 'boolean') {
         return [];
     }
@@ -574,15 +553,7 @@ function resolveFullReloadConfig({ refresh: config }: Required<PluginConfig>): P
         config = [{ paths: config }] as RefreshConfig[]
     }
 
-    return (config as RefreshConfig[]).flatMap(c => {
-        const plugin = fullReload(c.paths, c.config)
-
-        /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-        /** @ts-ignore */
-        plugin.__laravel_plugin_config = c
-
-        return plugin
-    })
+    return config as RefreshConfig[]
 }
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -527,6 +527,61 @@ describe('laravel-vite-plugin', () => {
         expect(resolvedConfig.server.cors).toBe(true)
     })
 
+    it('ignores Laravel directories in the dev server watcher by default', () => {
+        const plugin = laravel('resources/js/app.ts')[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        const ignored = config.server.watch.ignored as (file: string) => boolean
+        const root = process.cwd()
+
+        expect(typeof ignored).toBe('function')
+        expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
+        expect(ignored(path.join(root, 'storage', 'framework', 'views', 'cache.php'))).toBe(true)
+        expect(ignored(path.join(root, 'bootstrap', 'app.php'))).toBe(true)
+        expect(ignored(path.join(root, 'database', 'migrations', '2024.php'))).toBe(true)
+        expect(ignored(path.join(root, 'tests', 'Feature', 'ExampleTest.php'))).toBe(true)
+
+        // public/vendor must remain watched — `/vendor/**` style globs would misfire here.
+        expect(ignored(path.join(root, 'public', 'vendor', 'asset.js'))).toBe(false)
+        expect(ignored(path.join(root, 'resources', 'views', 'welcome.blade.php'))).toBe(false)
+        expect(ignored(path.join(root, 'storagerelated', 'foo.php'))).toBe(false)
+    })
+
+    it('does not set the watch ignored matcher during build', () => {
+        const plugin = laravel('resources/js/app.ts')[0]
+
+        const config = plugin.config({}, { command: 'build', mode: 'production' })
+
+        expect(config.server?.watch).toBeUndefined()
+    })
+
+    it("respects the user's server.watch.ignored config", () => {
+        const plugin = laravel('resources/js/app.ts')[0]
+
+        const userIgnored = ['**/my-custom-dir/**']
+        const config = plugin.config({
+            server: { watch: { ignored: userIgnored } },
+        }, { command: 'serve', mode: 'development' })
+
+        // When the user configured ignored explicitly, the plugin should not override it.
+        expect(config.server.watch?.ignored).toBeUndefined()
+    })
+
+    it('keeps refresh directories watched even if they overlap ignored defaults', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+            refresh: ['storage/framework/views/**'],
+        })[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        const ignored = config.server.watch.ignored as (file: string) => boolean
+        const root = process.cwd()
+
+        expect(ignored(path.join(root, 'storage', 'framework', 'views', 'cache.php'))).toBe(false)
+        // Other defaults remain ignored.
+        expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
+    })
+
     it('does not include assets plugin when no assets are configured', () => {
         const plugins = laravel('resources/js/app.ts')
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -588,20 +588,19 @@ describe('laravel-vite-plugin', () => {
         expect(config.server?.watch).toBeUndefined()
     })
 
-    it('discards refresh paths that do not fall within the root', () => {
+    it('ignores Laravel paths when refresh is enabled', () => {
         const plugin = laravel({
             input: 'resources/js/app.ts',
-            refresh: ['**', '../shared/views/**'],
+            refresh: true,
         })[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
         const ignored = config.server.watch.ignored as (file: string) => boolean
         const root = process.cwd()
 
-        // A refresh path resolving to the root, or outside of it, must not
-        // un-ignore the default paths.
         expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
         expect(ignored(path.join(root, 'storage', 'logs', 'laravel.log'))).toBe(true)
+        expect(ignored(path.join(root, 'resources', 'views', 'welcome.blade.php'))).toBe(false)
     })
 
     it('keeps refresh paths watched even if they overlap ignored paths', () => {
@@ -615,10 +614,11 @@ describe('laravel-vite-plugin', () => {
         const root = process.cwd()
 
         expect(ignored(path.join(root, 'storage', 'framework', 'views', 'cache.php'))).toBe(false)
-        // Ancestors of the refreshed path stay watched so the watcher descends into them.
-        expect(ignored(path.join(root, 'storage'))).toBe(false)
-        expect(ignored(path.join(root, 'storage', 'framework'))).toBe(false)
-        // Only the overlapping subtree is un-ignored — the rest of `storage` is still ignored.
+        // The refresh plugin adds its own glob to the watcher, so both the glob and
+        // the directory it resolves to must remain watched.
+        expect(ignored(path.join(root, 'storage', 'framework', 'views', '**'))).toBe(false)
+        expect(ignored(path.join(root, 'storage', 'framework', 'views'))).toBe(false)
+        // The rest of the ignored path is unaffected.
         expect(ignored(path.join(root, 'storage', 'logs', 'laravel.log'))).toBe(true)
         expect(ignored(path.join(root, 'storage', 'framework', 'cache', 'data.php'))).toBe(true)
         // Other defaults remain ignored.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -527,7 +527,7 @@ describe('laravel-vite-plugin', () => {
         expect(resolvedConfig.server.cors).toBe(true)
     })
 
-    it('ignores Laravel directories in the dev server watcher by default', () => {
+    it('ignores Laravel paths in the dev server watcher by default', () => {
         const plugin = laravel('resources/js/app.ts')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
@@ -540,6 +540,11 @@ describe('laravel-vite-plugin', () => {
         expect(ignored(path.join(root, 'bootstrap', 'app.php'))).toBe(true)
         expect(ignored(path.join(root, 'database', 'migrations', '2024.php'))).toBe(true)
         expect(ignored(path.join(root, 'tests', 'Feature', 'ExampleTest.php'))).toBe(true)
+        expect(ignored(path.join(root, '.phpunit.cache', 'test-results'))).toBe(true)
+
+        // The public/storage symlink resolves into the ignored storage directory,
+        // but the watcher follows symlinks and reports the symlinked path.
+        expect(ignored(path.join(root, 'public', 'storage', 'upload.jpg'))).toBe(true)
 
         // public/vendor must remain watched — `/vendor/**` style globs would misfire here.
         expect(ignored(path.join(root, 'public', 'vendor', 'asset.js'))).toBe(false)
@@ -563,11 +568,36 @@ describe('laravel-vite-plugin', () => {
             server: { watch: { ignored: userIgnored } },
         }, { command: 'serve', mode: 'development' })
 
-        // When the user configured ignored explicitly, the plugin should not override it.
-        expect(config.server.watch?.ignored).toBeUndefined()
+        expect(config.server.watch?.ignored).toBe(userIgnored)
     })
 
-    it('keeps refresh directories watched even if they overlap ignored defaults', () => {
+    it('does not re-enable the watcher when the user has disabled it', () => {
+        const plugin = laravel('resources/js/app.ts')[0]
+
+        const config = plugin.config({
+            server: { watch: null },
+        }, { command: 'serve', mode: 'development' })
+
+        expect(config.server?.watch).toBeUndefined()
+    })
+
+    it('discards refresh paths that do not fall within the root', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+            refresh: ['**', '../shared/views/**'],
+        })[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        const ignored = config.server.watch.ignored as (file: string) => boolean
+        const root = process.cwd()
+
+        // A refresh path resolving to the root, or outside of it, must not
+        // un-ignore the default paths.
+        expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
+        expect(ignored(path.join(root, 'storage', 'logs', 'laravel.log'))).toBe(true)
+    })
+
+    it('keeps refresh paths watched even if they overlap ignored paths', () => {
         const plugin = laravel({
             input: 'resources/js/app.ts',
             refresh: ['storage/framework/views/**'],
@@ -578,6 +608,12 @@ describe('laravel-vite-plugin', () => {
         const root = process.cwd()
 
         expect(ignored(path.join(root, 'storage', 'framework', 'views', 'cache.php'))).toBe(false)
+        // Ancestors of the refreshed path stay watched so the watcher descends into them.
+        expect(ignored(path.join(root, 'storage'))).toBe(false)
+        expect(ignored(path.join(root, 'storage', 'framework'))).toBe(false)
+        // Only the overlapping subtree is un-ignored — the rest of `storage` is still ignored.
+        expect(ignored(path.join(root, 'storage', 'logs', 'laravel.log'))).toBe(true)
+        expect(ignored(path.join(root, 'storage', 'framework', 'cache', 'data.php'))).toBe(true)
         // Other defaults remain ignored.
         expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
     })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import fs from 'fs'
-import laravel from '../src'
+import laravel, { defaultIgnorePathsWhenWatching } from '../src'
 import { resolvePageComponent } from '../src/inertia-helpers';
 import path from 'path';
 
@@ -22,7 +22,8 @@ vi.mock('fs', async () => {
                 'public/storage/',
                 'storage/',
                 'tests/',
-                'vendor/'
+                'vendor/',
+                'my-ignored-dir/'
             ].includes(path) || actual.existsSync(path)
         }
     }
@@ -623,6 +624,49 @@ describe('laravel-vite-plugin', () => {
         expect(ignored(path.join(root, 'storage', 'framework', 'cache', 'data.php'))).toBe(true)
         // Other defaults remain ignored.
         expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
+    })
+
+    it('replaces the default ignored paths when ignorePathsWhenWatching is configured', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+            ignorePathsWhenWatching: ['my-ignored-dir/'],
+        })[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        const ignored = config.server.watch.ignored as (file: string) => boolean
+        const root = process.cwd()
+
+        expect(ignored(path.join(root, 'my-ignored-dir', 'foo.php'))).toBe(true)
+        // A custom list fully replaces the defaults, rather than merging with them.
+        expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(false)
+    })
+
+    it('allows the default ignored paths to be extended via ignorePathsWhenWatching', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+            ignorePathsWhenWatching: [...defaultIgnorePathsWhenWatching, 'my-ignored-dir/'],
+        })[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        const ignored = config.server.watch.ignored as (file: string) => boolean
+        const root = process.cwd()
+
+        expect(ignored(path.join(root, 'my-ignored-dir', 'foo.php'))).toBe(true)
+        expect(ignored(path.join(root, 'vendor', 'laravel', 'framework', 'foo.php'))).toBe(true)
+    })
+
+    it('ignores a user-configured path even if it does not exist yet at startup', () => {
+        const plugin = laravel({
+            input: 'resources/js/app.ts',
+            // Not registered in the fs mock, so existsSync would report it as missing.
+            ignorePathsWhenWatching: ['not-yet-created-dir/'],
+        })[0]
+
+        const config = plugin.config({}, { command: 'serve', mode: 'development' })
+        const ignored = config.server.watch.ignored as (file: string) => boolean
+        const root = process.cwd()
+
+        expect(ignored(path.join(root, 'not-yet-created-dir', 'foo.php'))).toBe(true)
     })
 
     it('does not include assets plugin when no assets are configured', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -15,7 +15,14 @@ vi.mock('fs', async () => {
                 'app/View/Components/',
                 'resources/views/',
                 'lang/',
-                'routes/'
+                'routes/',
+                '.phpunit.cache/',
+                'bootstrap/',
+                'database/',
+                'public/storage/',
+                'storage/',
+                'tests/',
+                'vendor/'
             ].includes(path) || actual.existsSync(path)
         }
     }


### PR DESCRIPTION
This PR adds a default `server.watch.ignored` configuration that excludes Laravel directories which commonly cause unnecessary full page reloads during development:

- `bootstrap`
- `database`
- `storage`
- `tests`
- `vendor`

### Motivation

Multiple users have reported that Vite triggers unexpected page reloads when files change in directories like `storage/framework/views` or `vendor` (#324, #152, laravel/laravel#6500). @timacdonald outlined a preferred approach in https://github.com/laravel/laravel/pull/6500#issuecomment-2521763613 — handle this in the plugin with sensible defaults and an escape hatch.

Resolves #152
Related: #324, laravel/laravel#6500

### Approach

- A callback-based matcher checks only the top-level directory name relative to the project root, so nested paths like `public/vendor` are not affected.
- If the user has explicitly configured `server.watch.ignored`, the plugin does not override it.
- Directories referenced in the `refresh` config (e.g. `storage/framework/views/**`) are automatically excluded from the ignore list so they remain watched.
- Only applied during `serve`, not `build`.

### Added Tests

- Ignores default Laravel directories during dev server
- Does not set watch ignored during build
- Respects user's `server.watch.ignored` config
- Keeps refresh directories watched even if they overlap ignored defaults