### PR TITLE
GitHub Actions hardening

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
We are doing 3 things across the organization:

1. Pinning GitHub Actions to full commit SHAs (instead of mutable tags/branches).
2. Tightening workflow `permissions:` to least-privilege (write scope only where a step needs it).
3. Adding a Dependabot config to keep the pinned actions updated.

This pull request is part of that work.