### PR TITLE
[3.x] Use spec-compliant format() keywords for ttf, otf, and eot fonts

### DIFF
--- a/src/fonts/config.ts
+++ b/src/fonts/config.ts
@@ -5,6 +5,7 @@ import type {
     BaseFontOptions,
     FontDefinition,
     FontFormat,
+    FontFormatKeyword,
     FontProviderType,
     FontStyle,
     FontWeight,
@@ -50,14 +51,11 @@ const FORMAT_MAP: Record<string, FontFormat> = Object.fromEntries(
     FORMATS.map(f => [f.extension, f.type])
 )
 
-const FORMAT_KEYWORD_MAP: Record<FontFormat, string> = Object.fromEntries(
+const FORMAT_KEYWORD_MAP: Record<FontFormat, FontFormatKeyword> = Object.fromEntries(
     FORMATS.map(f => [f.type, f.keyword])
-) as Record<FontFormat, string>
+) as Record<FontFormat, FontFormatKeyword>
 
-/**
- * Resolve the CSS `@font-face` `format(...)` keyword for a font format.
- */
-export function formatKeyword(format: FontFormat): string {
+export function formatKeyword(format: FontFormat): FontFormatKeyword {
     return FORMAT_KEYWORD_MAP[format]
 }
 

--- a/src/fonts/config.ts
+++ b/src/fonts/config.ts
@@ -58,7 +58,7 @@ const FORMAT_KEYWORD_MAP: Record<FontFormat, string> = Object.fromEntries(
  * Resolve the CSS `@font-face` `format(...)` keyword for a font format.
  */
 export function formatKeyword(format: FontFormat): string {
-    return FORMAT_KEYWORD_MAP[format] ?? format
+    return FORMAT_KEYWORD_MAP[format]
 }
 
 const SUPPORTED_EXTENSIONS = FORMATS.map(f => f.extension)

--- a/src/fonts/config.ts
+++ b/src/fonts/config.ts
@@ -20,22 +20,27 @@ export const FORMATS: FormatConfig[] = [
     {
         type: 'woff2',
         extension: '.woff2',
+        keyword: 'woff2',
     },
     {
         type: 'woff',
         extension: '.woff',
+        keyword: 'woff',
     },
     {
         type: 'ttf',
         extension: '.ttf',
+        keyword: 'truetype',
     },
     {
         type: 'otf',
         extension: '.otf',
+        keyword: 'opentype',
     },
     {
         type: 'eot',
         extension: '.eot',
+        keyword: 'embedded-opentype',
     }
 ]
 
@@ -44,6 +49,17 @@ const FORMAT_PREFERENCE: FontFormat[] = FORMATS.map(f => f.type)
 const FORMAT_MAP: Record<string, FontFormat> = Object.fromEntries(
     FORMATS.map(f => [f.extension, f.type])
 )
+
+const FORMAT_KEYWORD_MAP: Record<FontFormat, string> = Object.fromEntries(
+    FORMATS.map(f => [f.type, f.keyword])
+) as Record<FontFormat, string>
+
+/**
+ * Resolve the CSS `@font-face` `format(...)` keyword for a font format.
+ */
+export function formatKeyword(format: FontFormat): string {
+    return FORMAT_KEYWORD_MAP[format] ?? format
+}
 
 const SUPPORTED_EXTENSIONS = FORMATS.map(f => f.extension)
 const SUPPORTED_GLOB = `*.{${SUPPORTED_EXTENSIONS.map((ext) => ext.slice(1)).join(",")}}`;

--- a/src/fonts/css-parser.ts
+++ b/src/fonts/css-parser.ts
@@ -1,12 +1,12 @@
 import { FORMATS } from './config.js'
 import type { FontFormat, FontStyle, FontWeight, ParsedFontFace, ParsedFontSrc } from './types.js'
 
-const FORMAT_ALIASES: Record<string, FontFormat> = {
-    truetype: "ttf",
-    opentype: "otf",
-    "embedded-opentype": "eot",
-    ...Object.fromEntries(FORMATS.map((f) => [f.type, f.type])),
-};
+const FORMAT_ALIASES = Object.fromEntries(
+    FORMATS.flatMap((format): [string, FontFormat][] => [
+        [format.type, format.type],
+        [format.keyword, format.type],
+    ]),
+) as Record<string, FontFormat>
 
 export function parseFontFaceCss(css: string): ParsedFontFace[] {
     const results: ParsedFontFace[] = []

--- a/src/fonts/css.ts
+++ b/src/fonts/css.ts
@@ -1,3 +1,4 @@
+import { formatKeyword } from './config.js'
 import type { ResolvedFontFamily, ResolvedFontFile, FallbackMetrics } from './types.js'
 
 function generateSrc(files: ResolvedFontFile[], filePathMap: Map<string, string>): string {
@@ -5,7 +6,7 @@ function generateSrc(files: ResolvedFontFile[], filePathMap: Map<string, string>
         .map(file => {
             const url = filePathMap.get(file.source) ?? file.source
 
-            return `url("${url}") format("${file.format}")`
+            return `url("${url}") format("${formatKeyword(file.format)}")`
         })
         .join(',\n    ')
 }
@@ -21,7 +22,7 @@ export function generateFontFace(
         const nonRangedFiles = variant.files.filter(f => ! f.unicodeRange)
 
         for (const file of rangedFiles) {
-            const fileSrc = `url("${filePathMap.get(file.source) ?? file.source}") format("${file.format}")`
+            const fileSrc = `url("${filePathMap.get(file.source) ?? file.source}") format("${formatKeyword(file.format)}")`
 
             rules.push([
                 '@font-face {',

--- a/src/fonts/types.ts
+++ b/src/fonts/types.ts
@@ -1,12 +1,9 @@
+export type FontFormatKeyword = 'collection' | 'embedded-opentype' | 'opentype' | 'svg' | 'truetype' | 'woff' | 'woff2'
+
 export type FormatConfig = {
     extension: string
     type: FontFormat
-    /**
-     * The keyword used in the CSS `@font-face` `src: ... format(...)` descriptor.
-     *
-     * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#font_formats}
-     */
-    keyword: string
+    keyword: FontFormatKeyword
 }
 
 export type FontProviderType = 'local' | 'google' | 'bunny' | 'fontsource'

--- a/src/fonts/types.ts
+++ b/src/fonts/types.ts
@@ -1,6 +1,12 @@
 export type FormatConfig = {
     extension: string
     type: FontFormat
+    /**
+     * The keyword used in the CSS `@font-face` `src: ... format(...)` descriptor.
+     *
+     * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#font_formats}
+     */
+    keyword: string
 }
 
 export type FontProviderType = 'local' | 'google' | 'bunny' | 'fontsource'

--- a/tests/fonts-css.test.ts
+++ b/tests/fonts-css.test.ts
@@ -92,6 +92,23 @@ describe('fonts css generation', () => {
             expect(css).toContain('unicode-range: U+0100-024F')
         })
 
+        it('uses spec-compliant format keywords for unicode-range files', () => {
+            const family = makeFamily({
+                variants: [{
+                    weight: 400,
+                    style: 'normal',
+                    files: [{ source: '/fonts/inter-latin.otf', format: 'otf', unicodeRange: 'U+0000-00FF' }],
+                }],
+            })
+
+            const css = generateFontFace(family, new Map([
+                ['/fonts/inter-latin.otf', 'assets/inter-latin.otf'],
+            ]))
+
+            expect(css).toContain('url("assets/inter-latin.otf") format("opentype")')
+            expect(css).toContain('unicode-range: U+0000-00FF')
+        })
+
         it('emits both ranged and non-ranged files when a variant mixes them', () => {
             const family = makeFamily({
                 variants: [{

--- a/tests/fonts-css.test.ts
+++ b/tests/fonts-css.test.ts
@@ -43,6 +43,31 @@ describe('fonts css generation', () => {
             expect(css).toContain('url("assets/inter-400-abc123.woff2") format("woff2")')
         })
 
+        it('uses the spec-compliant format keyword for each font format', () => {
+            const cases: [ResolvedFontFamily['variants'][number]['files'][number]['format'], string][] = [
+                ['woff2', 'woff2'],
+                ['woff', 'woff'],
+                ['ttf', 'truetype'],
+                ['otf', 'opentype'],
+                ['eot', 'embedded-opentype'],
+            ]
+
+            for (const [format, keyword] of cases) {
+                const source = `/fonts/inter-400.${format}`
+                const family = makeFamily({
+                    variants: [{
+                        weight: 400,
+                        style: 'normal',
+                        files: [{ source, format }],
+                    }],
+                })
+
+                const css = generateFontFace(family, new Map([[source, `assets/inter-400.${format}`]]))
+
+                expect(css).toContain(`url("assets/inter-400.${format}") format("${keyword}")`)
+            }
+        })
+
         it('generates separate rules for unicode-range subsets', () => {
             const family = makeFamily({
                 variants: [{

--- a/tests/fonts-providers.test.ts
+++ b/tests/fonts-providers.test.ts
@@ -197,6 +197,16 @@ describe('fonts providers', () => {
             const faces = parseFontFaceCss(css)
             expect(faces[0].src[0].format).toBe('otf')
         })
+
+        it('normalizes embedded-opentype format to eot', () => {
+            const css = `@font-face {
+                font-family: 'Test';
+                src: url(https://example.com/font.eot) format('embedded-opentype');
+            }`
+
+            const faces = parseFontFaceCss(css)
+            expect(faces[0].src[0].format).toBe('eot')
+        })
     })
 
     describe('remote fetcher User-Agent', () => {


### PR DESCRIPTION
Fixes #370

The fonts plugin emits the internal format type directly into the `@font-face` `src` descriptor, producing `format("otf")`, `format("ttf")`, and `format("eot")`. These are not valid [format keywords per the CSS spec](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src#font_formats), so browsers reject the source and local `ttf` / `otf` / `eot` fonts never render.

### Before

```css
src: url(".../andada-400-normal.otf") format("otf");
```

### After

```css
src: url(".../andada-400-normal.otf") format("opentype");
```

### Changes

- Added the spec `format()` keyword (`truetype`, `opentype`, `embedded-opentype`; `woff` / `woff2` unchanged) to the existing `FORMATS` config in `src/fonts/config.ts`, keeping it the single source of truth, and exposed a small `formatKeyword()` helper.
- Used the keyword in both places `src/fonts/css.ts` generates `format(...)` (regular and `unicode-range` subset rules).

The CSS parser already normalizes spec keywords on the way *in* (`FORMAT_ALIASES` in `src/fonts/css-parser.ts`); this completes the mapping on the way *out*.

Includes a test covering the emitted keyword for all five supported formats.

