### PR TITLE
[3.x] Respect the resolved Vite base in generated font CSS URLs

### DIFF
--- a/src/fonts/plugin.ts
+++ b/src/fonts/plugin.ts
@@ -127,7 +127,6 @@ export function assertFileRefsResolved(
 export function resolveFontsPlugin(
     fonts: FontDefinition[]|undefined,
     hotFile: string,
-    buildDirectory: string,
 ): Plugin[] {
     if (! fonts || fonts.length === 0) {
         return []
@@ -179,11 +178,12 @@ export function resolveFontsPlugin(
 
             const relativeFilePathMap = new Map<string, string>()
             const absoluteFilePathMap = new Map<string, string>()
+            const base = resolvedConfig.base.endsWith('/') ? resolvedConfig.base : `${resolvedConfig.base}/`
 
             for (const [source, ref] of fontsFileRefMap) {
                 const fileName = this.getFileName(ref)
                 relativeFilePathMap.set(source, fileName)
-                absoluteFilePathMap.set(source, `/${buildDirectory}/${fileName}`)
+                absoluteFilePathMap.set(source, `${base}${fileName}`)
             }
 
             const finalCss = generateFontCss(resolvedFamilies, absoluteFilePathMap, fontsFallbackMap)

--- a/src/fonts/plugin.ts
+++ b/src/fonts/plugin.ts
@@ -105,6 +105,22 @@ function emitFontAssets(
     return fileRefMap
 }
 
+function resolvePublicAssetUrl(base: string, fileName: string): string {
+    const normalizedBase = base.endsWith('/') ? base : `${base}/`
+
+    return `${normalizedBase}${fileName}`
+}
+
+function resolveCssAssetUrl(base: string, fileName: string, assetsDir: string): string {
+    if (base !== './' && base !== '') {
+        return resolvePublicAssetUrl(base, fileName)
+    }
+
+    const relativePath = path.posix.relative(assetsDir.replace(/\/+$/, ''), fileName)
+
+    return relativePath.startsWith('.') ? relativePath : `./${relativePath}`
+}
+
 /** @internal Exported for tests; not part of the public plugin API. */
 export function assertFileRefsResolved(
     families: ResolvedFontFamily[],
@@ -177,17 +193,18 @@ export function resolveFontsPlugin(
             assertFileRefsResolved(resolvedFamilies, fontsFileRefMap)
 
             const relativeFilePathMap = new Map<string, string>()
-            const absoluteFilePathMap = new Map<string, string>()
-            const base = resolvedConfig.base.endsWith('/') ? resolvedConfig.base : `${resolvedConfig.base}/`
+            const cssFilePathMap = new Map<string, string>()
+            const publicFilePathMap = new Map<string, string>()
 
             for (const [source, ref] of fontsFileRefMap) {
                 const fileName = this.getFileName(ref)
                 relativeFilePathMap.set(source, fileName)
-                absoluteFilePathMap.set(source, `${base}${fileName}`)
+                cssFilePathMap.set(source, resolveCssAssetUrl(resolvedConfig.base, fileName, resolvedConfig.build.assetsDir))
+                publicFilePathMap.set(source, resolvePublicAssetUrl(resolvedConfig.base, fileName))
             }
 
-            const finalCss = generateFontCss(resolvedFamilies, absoluteFilePathMap, fontsFallbackMap)
-            const { familyStyles, variables } = generateFamilyStyles(resolvedFamilies, absoluteFilePathMap, fontsFallbackMap)
+            const finalCss = generateFontCss(resolvedFamilies, cssFilePathMap, fontsFallbackMap)
+            const { familyStyles, variables } = generateFamilyStyles(resolvedFamilies, publicFilePathMap, fontsFallbackMap)
 
             const cssRef = this.emitFile({
                 type: 'asset',

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ export default function laravel(config: string|string[]|PluginConfig): [LaravelP
     return [
         resolveLaravelPlugin(pluginConfig),
         ...resolveAssetPlugin(pluginConfig.assets),
-        ...resolveFontsPlugin(pluginConfig.fonts, pluginConfig.hotFile, pluginConfig.buildDirectory),
+        ...resolveFontsPlugin(pluginConfig.fonts, pluginConfig.hotFile),
         ...resolveFullReloadConfig(pluginConfig) as Plugin[],
     ];
 }

--- a/tests/fonts-build.test.ts
+++ b/tests/fonts-build.test.ts
@@ -74,7 +74,7 @@ async function runBuild(
 
     const ctx = createMockContext()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(plugin.configResolved as any).call(ctx, { root: tmpRoot, command: 'build', base })
+    ;(plugin.configResolved as any).call(ctx, { root: tmpRoot, command: 'build', base, build: { assetsDir: 'assets' } })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (plugin.buildStart as any).call(ctx)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -192,6 +192,28 @@ describe('fonts plugin single-pass build', () => {
             const cssText = String(findCssAsset(ctx.bundle).source)
 
             expect(cssText).toMatch(/url\("https:\/\/cdn\.example\.com\/build\/assets\/test-[^"]*\.woff2"\)/)
+        } finally {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        }
+    })
+
+    it('uses CSS-relative font URLs when Vite uses a relative base', async () => {
+        const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-relative-base-'))
+        try {
+            const fontsConfig = [local('Test', {
+                optimizedFallbacks: false,
+                variants: [{ src: FIXTURE_FONT, weight: 400, style: 'normal' }],
+            })]
+
+            const { ctx } = await runBuild(fontsConfig, tmpRoot, './')
+
+            const cssText = String(findCssAsset(ctx.bundle).source)
+            const manifest = JSON.parse(String(findManifestAsset(ctx.bundle).source))
+
+            expect(cssText).toMatch(/url\("\.\/test-[^"]*\.woff2"\)/)
+            expect(cssText).not.toMatch(/url\("\.\/assets\//)
+
+            expect(manifest.style.familyStyles.test).toMatch(/url\("\.\/assets\/test-[^"]*\.woff2"\)/)
         } finally {
             fs.rmSync(tmpRoot, { recursive: true, force: true })
         }

--- a/tests/fonts-build.test.ts
+++ b/tests/fonts-build.test.ts
@@ -67,13 +67,14 @@ function buildAssetFileName(name: string): string {
 async function runBuild(
     fonts: FontDefinition[],
     tmpRoot: string,
+    base = '/build/',
 ): Promise<{ ctx: MockContext, plugin: ReturnType<typeof resolveFontsPlugin>[number] }> {
     const hotFile = path.join(tmpRoot, 'hot')
-    const [plugin] = resolveFontsPlugin(fonts, hotFile, 'build')
+    const [plugin] = resolveFontsPlugin(fonts, hotFile)
 
     const ctx = createMockContext()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(plugin.configResolved as any).call(ctx, { root: tmpRoot, command: 'build' })
+    ;(plugin.configResolved as any).call(ctx, { root: tmpRoot, command: 'build', base })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (plugin.buildStart as any).call(ctx)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -147,6 +148,50 @@ describe('fonts plugin single-pass build', () => {
             // The @font-face weight itself must keep the space-separated range.
             const cssText = String(findCssAsset(ctx.bundle).source)
             expect(cssText).toContain('font-weight: 100 900;')
+        } finally {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        }
+    })
+
+    it('prefixes CSS font URLs with the resolved base for subdirectory deployments', async () => {
+        const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-base-'))
+        try {
+            const fontsConfig = [local('Test', {
+                optimizedFallbacks: false,
+                variants: [{ src: FIXTURE_FONT, weight: 400, style: 'normal' }],
+            })]
+
+            const { ctx } = await runBuild(fontsConfig, tmpRoot, '/v2/build/')
+
+            const cssText = String(findCssAsset(ctx.bundle).source)
+            const manifest = JSON.parse(String(findManifestAsset(ctx.bundle).source))
+
+            expect(cssText).toMatch(/url\("\/v2\/build\/assets\/test-[^"]*\.woff2"\)/)
+            expect(cssText).not.toMatch(/url\("\/build\//)
+
+            // Inline family styles in the manifest must use the same base.
+            expect(manifest.style.familyStyles.test).toMatch(/url\("\/v2\/build\/assets\/test-[^"]*\.woff2"\)/)
+
+            // Manifest file paths stay relative so Laravel can resolve them itself.
+            expect(manifest.preloads[0].file).toMatch(/^assets\/test-[^"]*\.woff2$/)
+        } finally {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        }
+    })
+
+    it('prefixes CSS font URLs with an absolute ASSET_URL base', async () => {
+        const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-cdn-'))
+        try {
+            const fontsConfig = [local('Test', {
+                optimizedFallbacks: false,
+                variants: [{ src: FIXTURE_FONT, weight: 400, style: 'normal' }],
+            })]
+
+            const { ctx } = await runBuild(fontsConfig, tmpRoot, 'https://cdn.example.com/build/')
+
+            const cssText = String(findCssAsset(ctx.bundle).source)
+
+            expect(cssText).toMatch(/url\("https:\/\/cdn\.example\.com\/build\/assets\/test-[^"]*\.woff2"\)/)
         } finally {
             fs.rmSync(tmpRoot, { recursive: true, force: true })
         }

--- a/tests/fonts-dev.test.ts
+++ b/tests/fonts-dev.test.ts
@@ -372,7 +372,7 @@ describe('fonts plugin hot-manifest cleanup', () => {
         hotManifestPath: string
         server: FakeServer
     } {
-        const [plugin] = resolveFontsPlugin([google('Inter')], hotFile, 'build')
+        const [plugin] = resolveFontsPlugin([google('Inter')], hotFile)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ;(plugin.configResolved as any)({ root: tmpDir, command: 'serve' })
 


### PR DESCRIPTION
Fixes #366

`local()` (and remote) fonts generate production `@font-face` URLs from `buildDirectory` alone, producing `/build/assets/...` even when the app is deployed under a subdirectory (`base: '/v2/build/'`) or served from a CDN via `ASSET_URL`. The preload links are unaffected because the font manifest stores relative file paths that the Laravel side resolves itself — but the URLs embedded in the emitted `fonts.css` and in the inline `familyStyles` 404 in those deployments.

### Before

```css
src: url("/build/assets/brand-sans-400-normal-D4x1cWHb.woff2") format("woff2");
```

### After (with `base: '/v2/build/'`)

```css
src: url("/v2/build/assets/brand-sans-400-normal-D4x1cWHb.woff2") format("woff2");
```

### Changes

- `generateBundle` now prefixes font file URLs with the resolved Vite `base` instead of hardcoding `/${buildDirectory}/`. The Laravel plugin already derives `base` from `ASSET_URL` + `buildDirectory` (and respects a user-supplied `base`), so this covers subdirectory deployments, CDN URLs, and the default case (`/build/`) identically.
- The now-unused `buildDirectory` parameter was dropped from the internal `resolveFontsPlugin()`.
- Manifest file paths remain relative — preload resolution on the Laravel side is unchanged.

Includes tests for a subdirectory base and an absolute CDN-style base, asserting both the emitted CSS and the inline `familyStyles`, and that manifest paths stay relative.
