### PR TITLE
[3.x] Warn when optimized font fallbacks cannot be generated

### DIFF
--- a/src/fonts/fallback.ts
+++ b/src/fonts/fallback.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'url'
 import type { FallbackCategory, FallbackEntry, FallbackMetrics } from './types.js'
 
 // Canonical OS/2 metrics for the three system fonts Fontaine uses. Values sourced
@@ -35,6 +36,12 @@ function resolveFallbackCategory(category: unknown): FallbackCategory {
     return validCategories.includes(category as FallbackCategory) ? category as FallbackCategory : 'sans-serif';
 }
 
+function resolveMetricsSource(fontSource: string): string | URL {
+    return /^[a-z][a-z\d+.-]*:\/\//i.test(fontSource)
+        ? fontSource
+        : pathToFileURL(fontSource)
+}
+
 export async function generateFallbackMetrics(
     fontSource: string,
     warn: (message: string) => void = () => undefined,
@@ -51,7 +58,7 @@ export async function generateFallbackMetrics(
     }
 
     try {
-        const metrics = await fontaine.readMetrics(fontSource)
+        const metrics = await fontaine.readMetrics(resolveMetricsSource(fontSource))
 
         if (! metrics) {
             warn(`Unable to read font metrics from [${fontSource}]. Skipping optimized fallback generation for this font.`)

--- a/src/fonts/fallback.ts
+++ b/src/fonts/fallback.ts
@@ -37,19 +37,33 @@ function resolveFallbackCategory(category: unknown): FallbackCategory {
 
 export async function generateFallbackMetrics(
     fontSource: string,
+    warn: (message: string) => void = () => undefined,
 ): Promise<FallbackMetrics|undefined> {
+    let fontaine
+
     try {
         // @ts-expect-error — fontaine is an optional peer dependency
-        const fontaine = await import('fontaine')
+        fontaine = await import('fontaine')
+    } catch {
+        warn('Optimized font fallbacks require the optional "fontaine" package. Install it, or set "optimizedFallbacks: false" on your fonts to disable the feature.')
+
+        return undefined
+    }
+
+    try {
         const metrics = await fontaine.readMetrics(fontSource)
 
         if (! metrics) {
+            warn(`Unable to read font metrics from [${fontSource}]. Skipping optimized fallback generation for this font.`)
+
             return undefined
         }
 
         const { ascent, descent, lineGap, unitsPerEm, xWidthAvg, category } = metrics
 
         if (ascent == null || descent == null || lineGap == null || unitsPerEm == null) {
+            warn(`Unable to read font metrics from [${fontSource}]. Skipping optimized fallback generation for this font.`)
+
             return undefined
         }
 
@@ -68,7 +82,9 @@ export async function generateFallbackMetrics(
             lineGapOverride: `${(lineGap / adjustedEm * 100).toFixed(2)}%`,
             sizeAdjust: `${(sizeAdjust * 100).toFixed(2)}%`,
         }
-    } catch {
+    } catch (e) {
+        warn(`Unable to generate an optimized font fallback from [${fontSource}]: ${e instanceof Error ? e.message : String(e)}`)
+
         return undefined
     }
 }

--- a/src/fonts/plugin.ts
+++ b/src/fonts/plugin.ts
@@ -49,8 +49,17 @@ async function resolveFontFamilies(
 
 async function buildFallbackMap(
     families: ResolvedFontFamily[],
+    warn: (message: string) => void,
 ): Promise<Map<string, { fallbackFamily: string, metrics: FallbackMetrics }>> {
     const fallbackMap = new Map<string, { fallbackFamily: string, metrics: FallbackMetrics }>()
+    const warned = new Set<string>()
+
+    const warnOnce = (message: string): void => {
+        if (! warned.has(message)) {
+            warned.add(message)
+            warn(message)
+        }
+    }
 
     for (const family of families) {
         if (! family.optimizedFallbacks) {
@@ -63,13 +72,22 @@ async function buildFallbackMap(
             continue
         }
 
-        const metrics = await generateFallbackMetrics(firstFile.source)
+        const metrics = await generateFallbackMetrics(firstFile.source, warnOnce)
 
         if (metrics) {
             fallbackMap.set(family.alias, {
                 fallbackFamily: `${family.family} fallback`,
                 metrics,
             })
+        }
+    }
+
+    // Disable optimized fallbacks for families without generated metrics so
+    // the CSS variables and manifest never reference a fallback font face
+    // that was not emitted.
+    for (const family of families) {
+        if (family.optimizedFallbacks && ! fallbackMap.has(family.alias)) {
+            family.optimizedFallbacks = false
         }
     }
 
@@ -182,7 +200,7 @@ export function resolveFontsPlugin(
             }
 
             fontsFileRefMap = emitFontAssets(resolvedFamilies, (opts) => this.emitFile(opts))
-            fontsFallbackMap = await buildFallbackMap(resolvedFamilies)
+            fontsFallbackMap = await buildFallbackMap(resolvedFamilies, (message) => this.warn(message))
         },
 
         generateBundle() {
@@ -242,7 +260,7 @@ export function resolveFontsPlugin(
 
                     fontMiddleware.update(resolvedFamilies)
 
-                    const fallbackMap = await buildFallbackMap(resolvedFamilies)
+                    const fallbackMap = await buildFallbackMap(resolvedFamilies, (message) => server.config.logger.warn(`[laravel:fonts] ${message}`))
                     const urlMap = buildDevUrlMap(resolvedFamilies, devServerUrl)
                     const css = generateFontCss(resolvedFamilies, urlMap, fallbackMap)
                     const { familyStyles, variables } = generateFamilyStyles(resolvedFamilies, urlMap, fallbackMap)

--- a/tests/fonts-build.test.ts
+++ b/tests/fonts-build.test.ts
@@ -22,13 +22,16 @@ type MockContext = {
     refs: Map<string, string>
     counter: number
     bundle: Bundle
+    warnings: string[]
     emitFile: (opts: { type: 'asset', name?: string, fileName?: string, source: string | Buffer }) => string
     getFileName: (ref: string) => string
+    warn: (message: string) => void
 }
 
 function createMockContext(): MockContext {
     const refs = new Map<string, string>()
     const bundle: Bundle = {}
+    const warnings: string[] = []
     let counter = 0
 
     const emitFile: MockContext['emitFile'] = (opts) => {
@@ -54,7 +57,7 @@ function createMockContext(): MockContext {
         return name
     }
 
-    return { refs, counter, bundle, emitFile, getFileName }
+    return { refs, counter, bundle, warnings, emitFile, getFileName, warn: (message) => warnings.push(message) }
 }
 
 function buildAssetFileName(name: string): string {
@@ -214,6 +217,30 @@ describe('fonts plugin single-pass build', () => {
             expect(cssText).not.toMatch(/url\("\.\/assets\//)
 
             expect(manifest.style.familyStyles.test).toMatch(/url\("\.\/assets\/test-[^"]*\.woff2"\)/)
+        } finally {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        }
+    })
+
+    it('warns and drops the fallback family when fallback metrics cannot be generated', async () => {
+        const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-fallback-'))
+        try {
+            const fontsConfig = [local('Test', {
+                optimizedFallbacks: true,
+                fallbacks: ['sans-serif'],
+                variants: [{ src: FIXTURE_FONT, weight: 400, style: 'normal' }],
+            })]
+
+            const { ctx } = await runBuild(fontsConfig, tmpRoot)
+
+            expect(ctx.warnings.length).toBeGreaterThan(0)
+
+            const cssText = String(findCssAsset(ctx.bundle).source)
+            const manifest = JSON.parse(String(findManifestAsset(ctx.bundle).source))
+
+            expect(cssText).toContain('--font-test: "Test", sans-serif;')
+            expect(cssText).not.toContain('Test fallback')
+            expect(manifest.families.test.fallbackFamily).toBeUndefined()
         } finally {
             fs.rmSync(tmpRoot, { recursive: true, force: true })
         }

--- a/tests/fonts-dev.test.ts
+++ b/tests/fonts-dev.test.ts
@@ -6,8 +6,14 @@ import { PassThrough, Readable } from 'stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildDevUrlMap, createFontMiddleware } from '../src/fonts/dev-server'
 import { resolveFontsPlugin } from '../src/fonts/plugin'
-import { google } from '../src/fonts/providers/providers'
+import { google, local } from '../src/fonts/providers/providers'
 import type { ResolvedFontFamily } from '../src/fonts/types'
+
+vi.mock('fontaine', () => {
+    throw new Error("Cannot find package 'fontaine'")
+})
+
+const FIXTURE_FONT = path.resolve(__dirname, 'fixtures/fonts/test-font.woff2')
 
 function makeFamily(overrides?: Partial<ResolvedFontFamily>): ResolvedFontFamily {
     return {
@@ -342,6 +348,57 @@ describe('fonts dev server', () => {
             expect(cacheControl.toLowerCase()).not.toContain('immutable')
             expect(cacheControl.toLowerCase()).toMatch(/no-store|no-cache|max-age=\d{1,3}(?!\d)/)
         })
+    })
+})
+
+describe('fonts plugin dev fallback warnings', () => {
+    it('warns and drops the fallback family when dev fallback metrics cannot be generated', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-dev-fallback-'))
+        let httpServer: EventEmitter | undefined
+
+        try {
+            const hotFile = path.join(tmpDir, 'hot')
+            const hotManifestPath = path.resolve(path.dirname(hotFile), 'fonts-manifest.dev.json')
+            const [plugin] = resolveFontsPlugin([local('Test', {
+                fallbacks: ['sans-serif'],
+                variants: [{ src: FIXTURE_FONT, weight: 400, style: 'normal' }],
+            })], hotFile, 'build')
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(plugin.configResolved as any)({ root: tmpDir, command: 'serve' })
+
+            const warn = vi.fn()
+            httpServer = new EventEmitter()
+            const server = {
+                config: {
+                    root: tmpDir,
+                    command: 'serve',
+                    server: { port: 5173 },
+                    logger: { error: vi.fn(), warn },
+                },
+                middlewares: { use: vi.fn() },
+                httpServer,
+            }
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(plugin.configureServer as any)(server)
+
+            const [onListening] = server.httpServer.listeners('listening') as Array<() => Promise<void>>
+            await onListening()
+
+            expect(warn).toHaveBeenCalledTimes(1)
+            expect(warn.mock.calls[0][0]).toContain('[laravel:fonts]')
+            expect(warn.mock.calls[0][0]).toContain('fontaine')
+
+            const manifest = JSON.parse(fs.readFileSync(hotManifestPath, 'utf-8'))
+
+            expect(manifest.style.inline).toContain('--font-test: "Test", sans-serif;')
+            expect(manifest.style.inline).not.toContain('Test fallback')
+            expect(manifest.families.test.fallbackFamily).toBeUndefined()
+        } finally {
+            httpServer?.emit('close')
+            fs.rmSync(tmpDir, { recursive: true, force: true })
+        }
     })
 })
 

--- a/tests/fonts-fallback-missing.test.ts
+++ b/tests/fonts-fallback-missing.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateFallbackMetrics } from '../src/fonts/fallback'
+
+// Simulate fontaine not being installed: it is an optional peer dependency
+// and optimizedFallbacks defaults to true, so this is a common state.
+vi.mock('fontaine', () => {
+    throw new Error("Cannot find package 'fontaine'")
+})
+
+describe('generateFallbackMetrics without fontaine installed', () => {
+    it('warns that fontaine is required and returns undefined', async () => {
+        const warn = vi.fn()
+
+        const metrics = await generateFallbackMetrics('/fake/inter.woff2', warn)
+
+        expect(metrics).toBeUndefined()
+        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn.mock.calls[0][0]).toContain('fontaine')
+        expect(warn.mock.calls[0][0]).toContain('optimizedFallbacks')
+    })
+
+    it('returns undefined without warning when no warn callback is given', async () => {
+        await expect(generateFallbackMetrics('/fake/inter.woff2')).resolves.toBeUndefined()
+    })
+})

--- a/tests/fonts-fallback.test.ts
+++ b/tests/fonts-fallback.test.ts
@@ -183,4 +183,54 @@ describe('generateFallbackMetrics', () => {
         const sizeAdjust = (realFont.xWidthAvg / realFont.unitsPerEm) / (ARIAL.xWidthAvg / ARIAL.unitsPerEm)
         expect(parseFloat(metrics!.sizeAdjust)).toBeCloseTo(sizeAdjust * 100, 1)
     })
+
+    it('warns when metrics cannot be read from the font', async () => {
+        readMetricsMock.mockResolvedValue(null)
+        const warn = vi.fn()
+
+        const metrics = await generateFallbackMetrics('/fake/unreadable.woff2', warn)
+
+        expect(metrics).toBeUndefined()
+        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn.mock.calls[0][0]).toContain('/fake/unreadable.woff2')
+    })
+
+    it('warns when required metric fields are missing', async () => {
+        readMetricsMock.mockResolvedValue({ unitsPerEm: 2048, category: 'sans-serif' })
+        const warn = vi.fn()
+
+        const metrics = await generateFallbackMetrics('/fake/partial.woff2', warn)
+
+        expect(metrics).toBeUndefined()
+        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn.mock.calls[0][0]).toContain('/fake/partial.woff2')
+    })
+
+    it('warns with the underlying error when reading metrics throws', async () => {
+        readMetricsMock.mockRejectedValue(new Error('corrupt font table'))
+        const warn = vi.fn()
+
+        const metrics = await generateFallbackMetrics('/fake/corrupt.woff2', warn)
+
+        expect(metrics).toBeUndefined()
+        expect(warn).toHaveBeenCalledTimes(1)
+        expect(warn.mock.calls[0][0]).toContain('corrupt font table')
+    })
+
+    it('does not warn when metrics generation succeeds', async () => {
+        readMetricsMock.mockResolvedValue({
+            ascent: 1950,
+            descent: -500,
+            lineGap: 0,
+            unitsPerEm: 2048,
+            xWidthAvg: 1100,
+            category: 'sans-serif',
+        })
+        const warn = vi.fn()
+
+        const metrics = await generateFallbackMetrics('/fake/inter.woff2', warn)
+
+        expect(metrics).toBeDefined()
+        expect(warn).not.toHaveBeenCalled()
+    })
 })

--- a/tests/fonts-fallback.test.ts
+++ b/tests/fonts-fallback.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { pathToFileURL } from 'url'
 
 vi.mock('fontaine', () => ({
     readMetrics: vi.fn(),
@@ -53,6 +54,21 @@ describe('generateFallbackMetrics', () => {
         expect(parseFloat(metrics!.ascentOverride)).toBeCloseTo((realFont.ascent / adjustedEm) * 100, 1)
         expect(parseFloat(metrics!.descentOverride)).toBeCloseTo((Math.abs(realFont.descent) / adjustedEm) * 100, 1)
         expect(parseFloat(metrics!.lineGapOverride)).toBeCloseTo((realFont.lineGap / adjustedEm) * 100, 1)
+    })
+
+    it('reads local font metrics using a file URL', async () => {
+        readMetricsMock.mockResolvedValue({
+            ascent: 1950,
+            descent: -500,
+            lineGap: 0,
+            unitsPerEm: 2048,
+            xWidthAvg: 1100,
+            category: 'sans-serif',
+        })
+
+        await generateFallbackMetrics('/fake/inter.woff2')
+
+        expect(String(readMetricsMock.mock.calls[0][0])).toBe(pathToFileURL('/fake/inter.woff2').href)
     })
 
     it('computes size-adjust from Times New Roman metrics for serif fonts', async () => {


### PR DESCRIPTION
Fixes #369

`optimizedFallbacks` is enabled by default, but `fontaine` is an optional peer dependency, and every failure in fallback generation is silently swallowed by a bare `catch`. As reported in #369, this leaves users with:

- No fallback `@font-face` rules and no explanation why — whether `fontaine` is missing, `readMetrics()` returns `null` for the font, or reading throws.
- `:root` variables and the manifest still referencing a `"<family> fallback"` font face that was never emitted (e.g. `--font-sans: "Vinci Sans", "Vinci Sans fallback", system-ui, sans-serif`).

### Changes

- `generateFallbackMetrics()` now accepts a `warn` callback and reports each failure mode distinctly:
  - fontaine not installed → `Optimized font fallbacks require the optional "fontaine" package. Install it, or set "optimizedFallbacks: false" on your fonts to disable the feature.`
  - metrics unreadable / incomplete → `Unable to read font metrics from [<file>]. ...`
  - read error → `Unable to generate an optimized font fallback from [<file>]: <error>`
- Warnings are routed through `this.warn()` during build and `server.config.logger.warn()` during dev, deduplicated so the fontaine hint appears once rather than per family.
- When metrics could not be generated for a family, its `optimizedFallbacks` flag is now disabled before CSS/manifest generation, so the `:root` variables and the manifest `fallbackFamily` no longer reference a font face that does not exist.

Behavior when fallback generation succeeds is unchanged.

### Tests

- Warn-callback coverage for the `null` metrics, missing-fields, and throwing `readMetrics()` paths, plus a no-warning assertion on success.
- A dedicated test simulating `fontaine` not being installed.
- An end-to-end build test asserting a warning is emitted and that neither the generated CSS variables nor the manifest reference the ungenerated fallback family.

The second report in #369 (`readMetrics` returning `null` even with fontaine installed) is a fontaine-side limitation for that specific font file — with this change it now surfaces as an explicit warning naming the file instead of failing silently.