### PR TITLE
[3.x] Honor the subsets option for google and bunny providers

### DIFF
--- a/src/fonts/css-parser.ts
+++ b/src/fonts/css-parser.ts
@@ -10,16 +10,19 @@ const FORMAT_ALIASES: Record<string, FontFormat> = {
 
 export function parseFontFaceCss(css: string): ParsedFontFace[] {
     const results: ParsedFontFace[] = []
-    const ruleRegex = /@font-face\s*\{([^}]+)\}/g
+    // The Google and Bunny CSS APIs label each rule with a subset comment,
+    // e.g. `/* latin-ext */` directly above the @font-face block.
+    const ruleRegex = /(?:\/\*\s*([\w-]+)\s*\*\/\s*)?@font-face\s*\{([^}]+)\}/g
 
     let match
 
     while ((match = ruleRegex.exec(css)) !== null) {
-        const block = match[1]
+        const subset = match[1]
+        const block = match[2]
         const face = parseFontFaceBlock(block)
 
         if (face) {
-            results.push(face)
+            results.push(subset ? { ...face, subset } : face)
         }
     }
 

--- a/src/fonts/plugin.ts
+++ b/src/fonts/plugin.ts
@@ -112,7 +112,7 @@ function buildFontAssetName(
     const ext = file.format === 'woff2' ? '.woff2' : `.${file.format}`
     const weight = (sourceWeightMap.get(file.source)?.get(variant.style)?.size ?? 0) > 1
         ? 'variable'
-        : variant.weight
+        : String(variant.weight).replace(/\s+/g, '-')
 
     return `${slug}-${weight}-${variant.style}${ext}`
 }

--- a/src/fonts/plugin.ts
+++ b/src/fonts/plugin.ts
@@ -1,20 +1,22 @@
 import fs from 'fs'
 import path from 'path'
-import { validateFontsConfig, resolveLocalFont, familyToSlug } from './config.js'
-import { generateFontCss, generateFamilyStyles } from './css.js'
-import { buildManifest, buildDevManifest } from './manifest.js'
-import { resolveCacheDir } from './cache.js'
-import { resolveRemoteFont } from './providers/resolve-remote.js'
-import { resolveFontsourceFont } from './providers/resolve-fontsource.js'
-import { generateFallbackMetrics } from './fallback.js'
-import { buildDevUrlMap, createFontMiddleware } from './dev-server.js'
 import type { Plugin, ResolvedConfig } from 'vite'
-import type { FontDefinition, ResolvedFontFamily, FallbackMetrics } from './types.js'
+import { resolveCacheDir } from './cache.js'
+import { familyToSlug, resolveLocalFont, validateFontsConfig } from './config.js'
+import { generateFamilyStyles, generateFontCss } from './css.js'
+import { buildDevUrlMap, createFontMiddleware } from './dev-server.js'
+import { generateFallbackMetrics } from './fallback.js'
+import { buildDevManifest, buildManifest } from './manifest.js'
+import { resolveFontsourceFont } from './providers/resolve-fontsource.js'
+import { resolveRemoteFont } from './providers/resolve-remote.js'
+import type { FallbackMetrics, FontDefinition, ResolvedFontFamily, ResolvedFontFile, ResolvedFontVariant } from './types.js'
 
 const REMOTE_CSS_URLS: Record<string, string> = {
     google: 'https://fonts.googleapis.com/css2',
     bunny: 'https://fonts.bunny.net/css2',
 }
+
+type SourceWeightMap = Map<string, Map<string, Set<string>>>
 
 async function resolveFontFamilies(
     fonts: FontDefinition[],
@@ -76,11 +78,51 @@ async function buildFallbackMap(
     return fallbackMap
 }
 
+function buildSourceWeightMap(families: ResolvedFontFamily[]): SourceWeightMap {
+    const sourceWeightMap = new Map<string, Map<string, Set<string>>>()
+
+    for (const family of families) {
+        for (const variant of family.variants) {
+            for (const file of variant.files) {
+                if (! sourceWeightMap.has(file.source)) {
+                    sourceWeightMap.set(file.source, new Map())
+                }
+
+                const styleWeights = sourceWeightMap.get(file.source)!
+
+                if (! styleWeights.has(variant.style)) {
+                    styleWeights.set(variant.style, new Set())
+                }
+
+                styleWeights.get(variant.style)!.add(String(variant.weight))
+            }
+        }
+    }
+
+    return sourceWeightMap
+}
+
+function buildFontAssetName(
+    family: ResolvedFontFamily,
+    variant: ResolvedFontVariant,
+    file: ResolvedFontFile,
+    sourceWeightMap: SourceWeightMap,
+): string {
+    const slug = familyToSlug(family.family)
+    const ext = file.format === 'woff2' ? '.woff2' : `.${file.format}`
+    const weight = (sourceWeightMap.get(file.source)?.get(variant.style)?.size ?? 0) > 1
+        ? 'variable'
+        : variant.weight
+
+    return `${slug}-${weight}-${variant.style}${ext}`
+}
+
 function emitFontAssets(
     families: ResolvedFontFamily[],
     emitFile: (opts: { type: 'asset', name: string, source: Buffer }) => string,
 ): Map<string, string> {
     const fileRefMap = new Map<string, string>()
+    const sourceWeightMap = buildSourceWeightMap(families)
 
     for (const family of families) {
         for (const variant of family.variants) {
@@ -90,11 +132,7 @@ function emitFontAssets(
                 }
 
                 const source = fs.readFileSync(file.source)
-                const slug = familyToSlug(family.family)
-                const ext = file.format === 'woff2' ? '.woff2' : `.${file.format}`
-                // Variable font weight ranges contain a space (e.g. "100 900").
-                const weight = String(variant.weight).replace(/\s+/g, '-')
-                const name = `${slug}-${weight}-${variant.style}${ext}`
+                const name = buildFontAssetName(family, variant, file, sourceWeightMap)
                 const ref = emitFile({ type: 'asset', name, source })
 
                 fileRefMap.set(file.source, ref)

--- a/src/fonts/providers/resolve-fontsource.ts
+++ b/src/fonts/providers/resolve-fontsource.ts
@@ -3,33 +3,48 @@ import path from 'path'
 import { createRequire } from 'module'
 import { parseFontFaceCss } from '../css-parser.js'
 import { familyToSlug, buildResolvedFamily } from '../config.js'
-import type { FontDefinition, ResolvedFontFamily, ResolvedFontFile, ResolvedFontVariant, FontStyle } from '../types.js'
+import type { FontDefinition, ResolvedFontFamily, ResolvedFontFile, ResolvedFontVariant, FontStyle, ParsedFontFace } from '../types.js'
 
-function buildCssFilePaths(definition: FontDefinition, packageDir: string, packageName: string): string[] {
-    const paths: string[] = []
+type FontsourceCssFile = {
+    fileName: string
+    filePath: string
+    weight: string
+    style: FontStyle
+}
+
+function buildCssFilePaths(definition: FontDefinition, packageDir: string, packageName: string): FontsourceCssFile[] {
+    const paths: FontsourceCssFile[] = []
 
     for (const weight of definition.weights) {
         for (const style of definition.styles) {
-            for (const subset of definition.subsets) {
-                const cssFileName = style === 'italic'
-                    ? `${subset}-${weight}-italic.css`
-                    : `${subset}-${weight}.css`
-                const cssFilePath = path.join(packageDir, cssFileName)
+            const cssFileName = style === 'italic'
+                ? `${weight}-italic.css`
+                : `${weight}.css`
+            const cssFilePath = path.join(packageDir, cssFileName)
 
-                if (! fs.existsSync(cssFilePath)) {
-                    throw new Error(
-                        `laravel-vite-plugin: Fontsource CSS file not found: "${cssFileName}" ` +
-                        `in package "${packageName}" for font "${definition.family}". ` +
-                        `Check that weight ${weight}, style "${style}", and subset "${subset}" are available.`
-                    )
-                }
-
-                paths.push(cssFilePath)
+            if (! fs.existsSync(cssFilePath)) {
+                throw new Error(
+                    `laravel-vite-plugin: Fontsource CSS file not found: "${cssFileName}" ` +
+                    `in package "${packageName}" for font "${definition.family}". ` +
+                    `Check that weight ${weight} and style "${style}" are available.`
+                )
             }
+
+            paths.push({ fileName: cssFileName, filePath: cssFilePath, weight: String(weight), style })
         }
     }
 
     return paths
+}
+
+function matchesFontsourceSubset(face: ParsedFontFace, subset: string): boolean {
+    const suffix = `-${subset}-${String(face.weight)}-${face.style}`
+
+    return face.src.some(src => {
+        const stem = path.basename(src.url).replace(/\.(?:woff2?|ttf|otf|eot)$/i, '')
+
+        return stem.endsWith(suffix)
+    })
 }
 
 export function resolveFontsourceVariants(
@@ -56,12 +71,21 @@ export function resolveFontsourceVariants(
     const variants: ResolvedFontVariant[] = []
     const cssFilePaths = buildCssFilePaths(definition, packageDir, packageName)
 
-    for (const cssFilePath of cssFilePaths) {
-        const faces = parseFontFaceCss(fs.readFileSync(cssFilePath, 'utf-8'))
+    for (const cssFile of cssFilePaths) {
+        const faces = parseFontFaceCss(fs.readFileSync(cssFile.filePath, 'utf-8'))
+        const matchedSubsets = new Set<string>()
 
         for (const face of faces) {
+            const subset = definition.subsets.find(subset => matchesFontsourceSubset(face, subset))
+
+            if (! subset) {
+                continue
+            }
+
+            matchedSubsets.add(subset)
+
             const files: ResolvedFontFile[] = face.src.map(src => {
-                const absolutePath = path.resolve(path.dirname(cssFilePath), src.url)
+                const absolutePath = path.resolve(path.dirname(cssFile.filePath), src.url)
 
                 if (! fs.existsSync(absolutePath)) {
                     throw new Error(
@@ -74,6 +98,16 @@ export function resolveFontsourceVariants(
             })
 
             variants.push({ weight: face.weight, style: face.style as FontStyle, files })
+        }
+
+        for (const subset of definition.subsets) {
+            if (! matchedSubsets.has(subset)) {
+                throw new Error(
+                    `laravel-vite-plugin: Fontsource subset "${subset}" not found in "${cssFile.fileName}" ` +
+                    `in package "${packageName}" for font "${definition.family}". ` +
+                    `Check that weight ${cssFile.weight}, style "${cssFile.style}", and subset "${subset}" are available.`
+                )
+            }
         }
     }
 

--- a/src/fonts/providers/resolve-remote.ts
+++ b/src/fonts/providers/resolve-remote.ts
@@ -51,9 +51,26 @@ export async function resolveRemoteVariants(
         )
     }
 
+    // The CSS2 APIs return rules for every available subset regardless of the
+    // requested ones, so filter by the subset labels in the response. Rules
+    // without a label are kept to stay compatible with unlabelled responses.
+    const requestedFaces = faces.filter(
+        face => ! face.subset || definition.subsets.includes(face.subset)
+    )
+
+    if (requestedFaces.length === 0) {
+        const available = [...new Set(faces.map(face => face.subset).filter(Boolean))]
+
+        throw new Error(
+            `laravel-vite-plugin: ${definition.provider} returned no @font-face rules matching the requested ` +
+            `subsets [${definition.subsets.join(', ')}] for "${definition.family}". ` +
+            `Available subsets: [${available.join(', ')}].`
+        )
+    }
+
     const variants: ResolvedFontVariant[] = []
 
-    for (const face of faces) {
+    for (const face of requestedFaces) {
         const files: ResolvedFontFile[] = []
 
         for (const src of face.src) {

--- a/src/fonts/types.ts
+++ b/src/fonts/types.ts
@@ -219,6 +219,11 @@ export type ParsedFontFace = {
     src: ParsedFontSrc[]
     unicodeRange?: string
     display?: string
+    /**
+     * The subset label from the CSS comment preceding the rule (e.g. "latin"),
+     * as emitted by the Google and Bunny CSS APIs.
+     */
+    subset?: string
 }
 
 export type ParsedFontSrc = {

--- a/tests/fonts-build.test.ts
+++ b/tests/fonts-build.test.ts
@@ -182,6 +182,29 @@ describe('fonts plugin single-pass build', () => {
             fs.rmSync(tmpRoot, { recursive: true, force: true })
         }
     })
+
+    it('names a source reused across multiple weights as variable', async () => {
+        const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-variable-'))
+        try {
+            const fontsConfig = [local('Test', {
+                optimizedFallbacks: false,
+                variants: [
+                    { src: FIXTURE_FONT, weight: 400, style: 'normal' },
+                    { src: FIXTURE_FONT, weight: 500, style: 'normal' },
+                ],
+            })]
+
+            const { ctx } = await runBuild(fontsConfig, tmpRoot)
+            const cssText = String(findCssAsset(ctx.bundle).source)
+            const manifestText = String(findManifestAsset(ctx.bundle).source)
+
+            expect(cssText).toContain('/build/assets/test-variable-normal-abc123.woff2')
+            expect(cssText).not.toContain('/build/assets/test-400-normal-abc123.woff2')
+            expect(manifestText).toContain('assets/test-variable-normal-abc123.woff2')
+        } finally {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        }
+    })
 })
 
 describe('assertFileRefsResolved', () => {

--- a/tests/fonts-providers.test.ts
+++ b/tests/fonts-providers.test.ts
@@ -1,17 +1,43 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { parseFontFaceCss } from '../src/fonts/css-parser'
 import { buildCss2Url, resolveRemoteVariants } from '../src/fonts/providers/resolve-remote'
+import { resolveFontsourceVariants } from '../src/fonts/providers/resolve-fontsource'
 import * as resolveRemoteModule from '../src/fonts/providers/resolve-remote'
 import * as cache from '../src/fonts/cache'
-import { google } from '../src/fonts/index'
+import { fontsource, google } from '../src/fonts/index'
 
 const GOOGLE_INTER_CSS = fs.readFileSync(
     path.resolve(__dirname, 'fixtures/providers/google-inter.css'),
     'utf-8',
 )
+
+const FAKE_FONTSOURCE_PACKAGE = '@fontsource/test-sans'
+
+function writeFile(filePath: string, contents: string | Buffer): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+}
+
+function writeFakeFontsourcePackage(projectRoot: string, css: string): void {
+    const packageDir = path.join(projectRoot, 'node_modules/@fontsource/test-sans')
+
+    writeFile(path.join(packageDir, 'package.json'), JSON.stringify({ name: FAKE_FONTSOURCE_PACKAGE }))
+    writeFile(path.join(packageDir, '400.css'), css)
+
+    for (const subset of ['latin', 'latin-ext']) {
+        // Fontsource's subset-specific files omit unicode-range; only the combined file has it.
+        writeFile(path.join(packageDir, `${subset}-400.css`), `@font-face {
+            font-family: 'Test Sans';
+            font-style: normal;
+            font-weight: 400;
+            src: url(./files/test-sans-${subset}-400-normal.woff2) format('woff2');
+        }`)
+        writeFile(path.join(packageDir, `files/test-sans-${subset}-400-normal.woff2`), 'font-bytes')
+    }
+}
 
 describe('fonts providers', () => {
     describe('buildCss2Url', () => {
@@ -274,10 +300,70 @@ describe('fonts providers', () => {
         })
     })
 
+    describe('fontsource resolver', () => {
+        let projectRoot: string
+
+        beforeEach(() => {
+            projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-fontsource-test-'))
+            writeFile(path.join(projectRoot, 'package.json'), JSON.stringify({ private: true }))
+        })
+
+        afterEach(() => {
+            fs.rmSync(projectRoot, { recursive: true, force: true })
+        })
+
+        it('preserves unicode-range when resolving multiple subsets', () => {
+            writeFakeFontsourcePackage(projectRoot, `/* test-sans-latin-ext-400-normal */
+                @font-face {
+                    font-family: 'Test Sans';
+                    font-style: normal;
+                    font-weight: 400;
+                    src: url(./files/test-sans-latin-ext-400-normal.woff2) format('woff2');
+                    unicode-range: U+0100-024F;
+                }
+
+                /* test-sans-latin-400-normal */
+                @font-face {
+                    font-family: 'Test Sans';
+                    font-style: normal;
+                    font-weight: 400;
+                    src: url(./files/test-sans-latin-400-normal.woff2) format('woff2');
+                    unicode-range: U+0000-00FF;
+                }`)
+
+            const variants = resolveFontsourceVariants(fontsource('Test Sans', {
+                package: FAKE_FONTSOURCE_PACKAGE,
+                subsets: ['latin', 'latin-ext'],
+            }), projectRoot)
+
+            const ranges = variants.flatMap(variant => variant.files.map(file => file.unicodeRange))
+
+            expect(variants).toHaveLength(2)
+            expect(ranges).toEqual(expect.arrayContaining(['U+0000-00FF', 'U+0100-024F']))
+            expect(ranges).not.toContain(undefined)
+        })
+
+        it('throws when a requested subset is missing from the combined CSS', () => {
+            writeFakeFontsourcePackage(projectRoot, `/* test-sans-latin-400-normal */
+                @font-face {
+                    font-family: 'Test Sans';
+                    font-style: normal;
+                    font-weight: 400;
+                    src: url(./files/test-sans-latin-400-normal.woff2) format('woff2');
+                    unicode-range: U+0000-00FF;
+                }`)
+
+            expect(() => resolveFontsourceVariants(fontsource('Test Sans', {
+                package: FAKE_FONTSOURCE_PACKAGE,
+                subsets: ['latin', 'latin-ext'],
+            }), projectRoot)).toThrow(/Fontsource subset "latin-ext" not found/)
+        })
+    })
+
     describe('remote fetcher User-Agent', () => {
         let cacheDir: string
-        let fetchTextSpy: ReturnType<typeof vi.spyOn>
-        let fetchBinarySpy: ReturnType<typeof vi.spyOn>
+        let fetchTextSpy: MockInstance<typeof cache.fetchTextAndCache>
+        let fetchBinarySpy: MockInstance<typeof cache.fetchAndCache>
 
         beforeEach(() => {
             cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-ua-test-'))

--- a/tests/fonts-providers.test.ts
+++ b/tests/fonts-providers.test.ts
@@ -197,6 +197,81 @@ describe('fonts providers', () => {
             const faces = parseFontFaceCss(css)
             expect(faces[0].src[0].format).toBe('otf')
         })
+
+        it('captures the subset label from the preceding comment', () => {
+            const faces = parseFontFaceCss(GOOGLE_INTER_CSS)
+
+            expect(faces.map(f => f.subset)).toEqual(['latin', 'latin-ext', 'latin'])
+        })
+
+        it('leaves subset undefined when no comment precedes the rule', () => {
+            const css = `@font-face {
+                font-family: 'Test';
+                src: url(https://example.com/font.woff2) format('woff2');
+            }`
+
+            const faces = parseFontFaceCss(css)
+
+            expect(faces).toHaveLength(1)
+            expect(faces[0].subset).toBeUndefined()
+        })
+    })
+
+    describe('remote subset filtering', () => {
+        let cacheDir: string
+
+        beforeEach(() => {
+            cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-subset-test-'))
+            vi.spyOn(cache, 'fetchTextAndCache').mockResolvedValue(GOOGLE_INTER_CSS)
+            vi.spyOn(cache, 'fetchAndCache').mockResolvedValue(Buffer.from('font-bytes'))
+        })
+
+        afterEach(() => {
+            vi.restoreAllMocks()
+            fs.rmSync(cacheDir, { recursive: true, force: true })
+        })
+
+        it('only keeps the default latin subset', async () => {
+            const variants = await resolveRemoteVariants(google('Inter', {
+                weights: [400, 700],
+            }), cacheDir, 'https://fonts.googleapis.com/css2')
+
+            // The fixture contains latin + latin-ext for 400 and latin for 700.
+            expect(variants).toHaveLength(2)
+            expect(variants.map(v => v.weight).sort()).toEqual([400, 700])
+        })
+
+        it('keeps every requested subset', async () => {
+            const variants = await resolveRemoteVariants(google('Inter', {
+                weights: [400, 700],
+                subsets: ['latin', 'latin-ext'],
+            }), cacheDir, 'https://fonts.googleapis.com/css2')
+
+            expect(variants).toHaveLength(3)
+        })
+
+        it('throws a clear error listing available subsets when none match', async () => {
+            await expect(resolveRemoteVariants(google('Inter', {
+                subsets: ['cyrillic'],
+            }), cacheDir, 'https://fonts.googleapis.com/css2')).rejects.toThrow(
+                /requested subsets \[cyrillic\].*Available subsets: \[latin, latin-ext\]/s,
+            )
+        })
+
+        it('keeps unlabelled rules regardless of requested subsets', async () => {
+            vi.mocked(cache.fetchTextAndCache).mockResolvedValue(`@font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 400;
+                src: url(https://example.com/inter.woff2) format('woff2');
+            }`)
+
+            const variants = await resolveRemoteVariants(google('Inter', {
+                subsets: ['latin'],
+            }), cacheDir, 'https://fonts.googleapis.com/css2')
+
+            expect(variants).toHaveLength(1)
+        })
     })
 
     describe('remote fetcher User-Agent', () => {

--- a/tests/fonts-providers.test.ts
+++ b/tests/fonts-providers.test.ts
@@ -224,6 +224,16 @@ describe('fonts providers', () => {
             expect(faces[0].src[0].format).toBe('otf')
         })
 
+        it('normalizes embedded-opentype format to eot', () => {
+            const css = `@font-face {
+                font-family: 'Test';
+                src: url(https://example.com/font.eot) format('embedded-opentype');
+            }`
+
+            const faces = parseFontFaceCss(css)
+            expect(faces[0].src[0].format).toBe('eot')
+        })
+
         it('captures the subset label from the preceding comment', () => {
             const faces = parseFontFaceCss(GOOGLE_INTER_CSS)
 
@@ -357,14 +367,6 @@ describe('fonts providers', () => {
                 package: FAKE_FONTSOURCE_PACKAGE,
                 subsets: ['latin', 'latin-ext'],
             }), projectRoot)).toThrow(/Fontsource subset "latin-ext" not found/)
-        it('normalizes embedded-opentype format to eot', () => {
-            const css = `@font-face {
-                font-family: 'Test';
-                src: url(https://example.com/font.eot) format('embedded-opentype');
-            }`
-
-            const faces = parseFontFaceCss(css)
-            expect(faces[0].src[0].format).toBe('eot')
         })
     })
 


### PR DESCRIPTION
Addresses Issue 1 of #365 (`subsets` is ignored by remote providers).

The Google and Bunny CSS2 APIs return `@font-face` rules for **every** available subset regardless of the `&subset=` parameter in the request, so the resolver downloaded and self-hosted all of them — `bunny('Inter', { subsets: ['latin'] })` still emitted all 7 subsets, and the `subsets` option silently did nothing. (Verified against both live APIs: each returns `latin`, `latin-ext`, `cyrillic`, `cyrillic-ext`, `greek`, `greek-ext`, and `vietnamese` for Inter even with `&subset=latin`.)

Both APIs label every rule with a subset comment:

```css
/* latin-ext */
@font-face {
  font-family: 'Inter';
  ...
}
```

### Changes

- The CSS parser now captures the subset label from the comment preceding each `@font-face` rule (`ParsedFontFace.subset`).
- `resolveRemoteVariants()` filters the parsed rules against the configured `subsets` before downloading any font files, so only the requested subsets are fetched and emitted.
- Rules without a subset label are kept, so unlabelled responses behave exactly as before.
- Requesting only subsets the family does not have now throws a clear error naming the available subsets instead of silently producing an empty result:
  > google returned no @font-face rules matching the requested subsets [arabic] for "Inter". Available subsets: [latin, latin-ext, ...].

### Note on default behavior

`subsets` defaults to `['latin']`, so default remote builds now self-host only the latin files instead of all subsets — this matches the documented default that previously had no effect. Since browsers already used `unicode-range` to fetch only needed subsets at runtime, this changes build output size, not rendering. Users who want more subsets opt in explicitly, e.g. `subsets: ['latin', 'latin-ext', 'cyrillic']`.

Issues 2 (variable fonts collapsing) and 3 (fontsource `unicode-range`) from #365 are separate problems and not covered here.