### PR TITLE
[3.x] Sanitize variable font weight ranges in emitted asset filenames

### DIFF
--- a/src/fonts/plugin.ts
+++ b/src/fonts/plugin.ts
@@ -92,7 +92,9 @@ function emitFontAssets(
                 const source = fs.readFileSync(file.source)
                 const slug = familyToSlug(family.family)
                 const ext = file.format === 'woff2' ? '.woff2' : `.${file.format}`
-                const name = `${slug}-${variant.weight}-${variant.style}${ext}`
+                // Variable font weight ranges contain a space (e.g. "100 900").
+                const weight = String(variant.weight).replace(/\s+/g, '-')
+                const name = `${slug}-${weight}-${variant.style}${ext}`
                 const ref = emitFile({ type: 'asset', name, source })
 
                 fileRefMap.set(file.source, ref)

--- a/tests/fonts-build.test.ts
+++ b/tests/fonts-build.test.ts
@@ -128,6 +128,30 @@ describe('fonts plugin single-pass build', () => {
         }
     })
 
+    it('sanitizes variable font weight ranges in emitted asset filenames', async () => {
+        const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-vf-'))
+        try {
+            const fontsConfig = [local('Test', {
+                optimizedFallbacks: false,
+                variants: [{ src: FIXTURE_FONT, weight: '100 900', style: 'normal' }],
+            })]
+
+            const { ctx } = await runBuild(fontsConfig, tmpRoot)
+
+            const fontAssets = Object.keys(ctx.bundle).filter(name => name.endsWith('.woff2'))
+
+            expect(fontAssets.length).toBe(1)
+            expect(fontAssets[0]).toContain('test-100-900-normal')
+            expect(fontAssets.every(name => ! name.includes(' '))).toBe(true)
+
+            // The @font-face weight itself must keep the space-separated range.
+            const cssText = String(findCssAsset(ctx.bundle).source)
+            expect(cssText).toContain('font-weight: 100 900;')
+        } finally {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        }
+    })
+
     it('gives distinct hashed URLs to each of multiple families that share a fallback keyword', async () => {
         const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fonts-build-multi-'))
         try {


### PR DESCRIPTION
Addresses the generated-filename portion of #352.

When a `local()` variant uses a variable font weight range, the range is concatenated directly into the emitted asset name, producing filenames with literal spaces:

```
public/build/assets/geist-100 900-normal-CYc--oWN.woff2
public/build/assets/geist-100 900-italic-CLbs5ZTV.woff2
```

As noted in #352, spaces in asset filenames can break some build tools and CDNs, and the output is inconsistent with how Vite names the same files when they go through the `assets` pipeline.

### Changes

Whitespace in the weight is replaced with a hyphen when building the emitted asset name:

```
public/build/assets/geist-100-900-normal-CYc--oWN.woff2
```

The `@font-face` `font-weight` descriptor is unaffected and keeps the space-separated range (`font-weight: 100 900;`). Static weights (e.g. `400`) produce the same names as before.

The remaining topics in #352 (dual `src` declarations with `tech('variations')`, `local()` source entries, and `font-variation-settings`) are feature requests and not covered here.