### PR TITLE
Ability to specify custom certificates path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             const env = loadEnv(mode, userConfig.envDir || process.cwd(), '')
             const assetUrl = env.ASSET_URL ?? ''
             const serverConfig = command === 'serve'
-                ? (resolveDevelopmentEnvironmentServerConfig(pluginConfig.detectTls) ?? resolveEnvironmentServerConfig(env))
+                ? (resolveDevelopmentEnvironmentServerConfig(pluginConfig.detectTls, env) ?? resolveEnvironmentServerConfig(env))
                 : undefined
 
             ensureCommandShouldRunInEnvironment(command, env)
@@ -589,7 +589,7 @@ function resolveHostFromEnv(env: Record<string, string>): string|undefined
 /**
  * Resolve the Herd or Valet server config for the given host.
  */
-function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
+function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null, env: Record<string, string>): {
     hmr?: { host: string }
     host?: string,
     https?: { cert: string, key: string }
@@ -598,29 +598,43 @@ function resolveDevelopmentEnvironmentServerConfig(host: string|boolean|null): {
         return
     }
 
+    // An optional certificate directory. When set, certificates are read from
+    // here instead of the Herd/Valet `Certificates` directory — useful when the
+    // dev certificates live elsewhere, such as a custom or containerized local
+    // setup or CI. With an explicit `detectTls` host, Herd or Valet need not be
+    // installed at all.
+    const certificatesPathOverride = env.LARAVEL_VITE_DEV_SERVER_CERTS_PATH
+
     const configPath = determineDevelopmentEnvironmentConfigPath();
 
-    if (typeof configPath === 'undefined' && host === null) {
+    if (typeof configPath === 'undefined' && typeof certificatesPathOverride === 'undefined' && host === null) {
         return
     }
 
-    if (typeof configPath === 'undefined') {
+    if (typeof configPath === 'undefined' && typeof certificatesPathOverride === 'undefined') {
         throw Error(`Unable to find the Herd or Valet configuration directory. Please check they are correctly installed.`)
     }
 
+    if ((host === true || host === null) && typeof configPath === 'undefined') {
+        throw Error(`Unable to resolve the host's TLD without a Herd or Valet configuration directory. Set \`detectTls\` to your hostname when using LARAVEL_VITE_DEV_SERVER_CERTS_PATH outside of Herd or Valet.`)
+    }
+
     const resolvedHost = host === true || host === null
-        ? path.basename(process.cwd()) + '.' + resolveDevelopmentEnvironmentTld(configPath)
+        ? path.basename(process.cwd()) + '.' + resolveDevelopmentEnvironmentTld(configPath as string)
         : host
 
-    const keyPath = path.resolve(configPath, 'Certificates', `${resolvedHost}.key`)
-    const certPath = path.resolve(configPath, 'Certificates', `${resolvedHost}.crt`)
+    const certificatesPath = certificatesPathOverride ?? path.resolve(configPath as string, 'Certificates')
+    const keyPath = path.resolve(certificatesPath, `${resolvedHost}.key`)
+    const certPath = path.resolve(certificatesPath, `${resolvedHost}.crt`)
 
     if (! fs.existsSync(keyPath) || ! fs.existsSync(certPath)) {
         if (host === null) {
             return
         }
 
-        if (configPath === herdMacConfigPath() || configPath === herdWindowsConfigPath()) {
+        if (typeof certificatesPathOverride === 'string') {
+            throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${certificatesPath}] directory specified by LARAVEL_VITE_DEV_SERVER_CERTS_PATH.`)
+        } else if (configPath === herdMacConfigPath() || configPath === herdWindowsConfigPath()) {
             throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site via the Herd UI.`)
         } else if (typeof host === 'string') {
             throw Error(`Unable to find certificate files for your host [${resolvedHost}] in the [${configPath}/Certificates] directory. Ensure you have secured the site by running \`valet secure ${host}\`.`)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import fs from 'fs'
+import os from 'os'
 import laravel from '../src'
 import { resolvePageComponent } from '../src/inertia-helpers';
 import path from 'path';
@@ -61,6 +62,40 @@ describe('laravel-vite-plugin', () => {
         expect(ssrConfig.build.rolldownOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
     })
 
+    it('resolves detectTls certificates from LARAVEL_VITE_DEV_SERVER_CERTS_PATH', () => {
+        const certDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-certs-'))
+        const host = 'my-app.test'
+        fs.writeFileSync(path.join(certDir, `${host}.key`), 'key')
+        fs.writeFileSync(path.join(certDir, `${host}.crt`), 'cert')
+        process.env.LARAVEL_VITE_DEV_SERVER_CERTS_PATH = certDir
+
+        try {
+            const plugin = laravel({ input: 'resources/js/app.ts', detectTls: host })[0]
+            const config = plugin.config({}, { command: 'serve', mode: 'development' })
+
+            expect(config.server.host).toBe(host)
+            expect(config.server.hmr.host).toBe(host)
+            expect(config.server.https.key).toBe(path.join(certDir, `${host}.key`))
+            expect(config.server.https.cert).toBe(path.join(certDir, `${host}.crt`))
+        } finally {
+            delete process.env.LARAVEL_VITE_DEV_SERVER_CERTS_PATH
+            fs.rmSync(certDir, { recursive: true, force: true })
+        }
+    })
+
+    it('throws a LARAVEL_VITE_DEV_SERVER_CERTS_PATH-specific error when the certificate is missing', () => {
+        const certDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-certs-'))
+        process.env.LARAVEL_VITE_DEV_SERVER_CERTS_PATH = certDir
+
+        try {
+            const plugin = laravel({ input: 'resources/js/app.ts', detectTls: 'my-app.test' })[0]
+            expect(() => plugin.config({}, { command: 'serve', mode: 'development' }))
+                .toThrowError(/LARAVEL_VITE_DEV_SERVER_CERTS_PATH/)
+        } finally {
+            delete process.env.LARAVEL_VITE_DEV_SERVER_CERTS_PATH
+            fs.rmSync(certDir, { recursive: true, force: true })
+        }
+    })
     it('accepts a full configuration', () => {
         const plugin = laravel({
             input: 'resources/js/app.ts',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -96,6 +96,96 @@ describe('laravel-vite-plugin', () => {
             fs.rmSync(certDir, { recursive: true, force: true })
         }
     })
+
+    it('resolves detectTls certificates from the Herd config directory', () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-home-'))
+        const herdCerts = path.join(home, 'Library', 'Application Support', 'Herd', 'config', 'valet', 'Certificates')
+        fs.mkdirSync(herdCerts, { recursive: true })
+        const host = 'my-app.test'
+        fs.writeFileSync(path.join(herdCerts, `${host}.key`), 'key')
+        fs.writeFileSync(path.join(herdCerts, `${host}.crt`), 'cert')
+        const homedir = vi.spyOn(os, 'homedir').mockReturnValue(home)
+
+        try {
+            const plugin = laravel({ input: 'resources/js/app.ts', detectTls: host })[0]
+            const config = plugin.config({}, { command: 'serve', mode: 'development' })
+
+            expect(config.server.host).toBe(host)
+            expect(config.server.hmr.host).toBe(host)
+            expect(config.server.https.key).toBe(path.join(herdCerts, `${host}.key`))
+            expect(config.server.https.cert).toBe(path.join(herdCerts, `${host}.crt`))
+        } finally {
+            homedir.mockRestore()
+            fs.rmSync(home, { recursive: true, force: true })
+        }
+    })
+
+    it('resolves detectTls certificates from the Valet config directory', () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-home-'))
+        const valetCerts = path.join(home, '.config', 'valet', 'Certificates')
+        fs.mkdirSync(valetCerts, { recursive: true })
+        const host = 'my-app.test'
+        fs.writeFileSync(path.join(valetCerts, `${host}.key`), 'key')
+        fs.writeFileSync(path.join(valetCerts, `${host}.crt`), 'cert')
+        const homedir = vi.spyOn(os, 'homedir').mockReturnValue(home)
+
+        try {
+            const plugin = laravel({ input: 'resources/js/app.ts', detectTls: host })[0]
+            const config = plugin.config({}, { command: 'serve', mode: 'development' })
+
+            expect(config.server.https.key).toBe(path.join(valetCerts, `${host}.key`))
+            expect(config.server.https.cert).toBe(path.join(valetCerts, `${host}.crt`))
+        } finally {
+            homedir.mockRestore()
+            fs.rmSync(home, { recursive: true, force: true })
+        }
+    })
+
+    it('prefers the Herd config directory over Valet when both exist', () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-home-'))
+        const host = 'my-app.test'
+        const herdCerts = path.join(home, 'Library', 'Application Support', 'Herd', 'config', 'valet', 'Certificates')
+        const valetCerts = path.join(home, '.config', 'valet', 'Certificates')
+        for (const dir of [herdCerts, valetCerts]) {
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, `${host}.key`), 'key')
+            fs.writeFileSync(path.join(dir, `${host}.crt`), 'cert')
+        }
+        const homedir = vi.spyOn(os, 'homedir').mockReturnValue(home)
+
+        try {
+            const plugin = laravel({ input: 'resources/js/app.ts', detectTls: host })[0]
+            const config = plugin.config({}, { command: 'serve', mode: 'development' })
+
+            expect(config.server.https.key).toBe(path.join(herdCerts, `${host}.key`))
+        } finally {
+            homedir.mockRestore()
+            fs.rmSync(home, { recursive: true, force: true })
+        }
+    })
+
+    it('derives the host from the config directory TLD when detectTls is true', () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-home-'))
+        const configDir = path.join(home, 'Library', 'Application Support', 'Herd', 'config', 'valet')
+        fs.mkdirSync(path.join(configDir, 'Certificates'), { recursive: true })
+        fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ tld: 'test' }))
+        const host = `${path.basename(process.cwd())}.test`
+        fs.writeFileSync(path.join(configDir, 'Certificates', `${host}.key`), 'key')
+        fs.writeFileSync(path.join(configDir, 'Certificates', `${host}.crt`), 'cert')
+        const homedir = vi.spyOn(os, 'homedir').mockReturnValue(home)
+
+        try {
+            const plugin = laravel({ input: 'resources/js/app.ts', detectTls: true })[0]
+            const config = plugin.config({}, { command: 'serve', mode: 'development' })
+
+            expect(config.server.host).toBe(host)
+            expect(config.server.https.key).toBe(path.join(configDir, 'Certificates', `${host}.key`))
+        } finally {
+            homedir.mockRestore()
+            fs.rmSync(home, { recursive: true, force: true })
+        }
+    })
+
     it('accepts a full configuration', () => {
         const plugin = laravel({
             input: 'resources/js/app.ts',


### PR DESCRIPTION
I've been running a custom local setup to utilize Caddy/frankenphp and noticed there is not a way to specify certs from a location outside Valet/Herd. This adds a specific env var that would allow for that scenario.

I also added tests to cover the Herd config and Valet config logic.