### PR TITLE
Handle null addresses on dev server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             server.httpServer?.once('listening', () => {
                 const address = server.httpServer?.address()
 
-                const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object'
+                const isAddressInfo = (x: string|AddressInfo|null|undefined): x is AddressInfo => typeof x === 'object' && x !== null
                 if (isAddressInfo(address)) {
                     viteDevServerUrl = userConfig.server?.origin ? userConfig.server.origin as DevServerUrl : resolveDevServerUrl(address, server.config, userConfig)
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -564,6 +564,39 @@ describe('laravel-vite-plugin', () => {
 
 })
 
+describe('dev server listening', () => {
+    it('does not throw when the server address is null', () => {
+        const plugin = laravel('resources/js/app.ts')[0]
+
+        /* @ts-ignore */
+        plugin.configResolved({ envDir: null, mode: 'development', command: 'serve', server: {}, base: '/build/' })
+
+        const listeners: Array<() => void> = []
+        const server = {
+            config: { base: '/build/', server: {}, logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+            middlewares: { use: vi.fn() },
+            httpServer: {
+                once: (event: string, listener: () => void) => {
+                    if (event === 'listening') {
+                        listeners.push(listener)
+                    }
+                },
+                address: () => null,
+            },
+        }
+
+        /* @ts-ignore */
+        plugin.configureServer(server)
+
+        const writeFileSync = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+
+        expect(() => listeners.forEach(listener => listener())).not.toThrow()
+        expect(writeFileSync).not.toHaveBeenCalled()
+
+        writeFileSync.mockRestore()
+    })
+})
+
 describe('inertia-helpers', () => {
     const path = './__data__/dummy.ts'
     it('pass glob value to resolvePageComponent', async () => {


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I've noticed some dev server crashes when the address is null. I'm guessing this is a race between Vite's rapid server restarts (e.g. on .env change) and the server, where the listening event fires before address() reports a valid address — so we null-check the guard instead of crashing.

Here was the stack trace:

```
  ➜  APP_URL: https://repo.test
  ➜  Using Valet certificate to secure Vite.
8:37:55 PM [vite] .env changed, restarting server...
8:37:55 PM [vite] .env changed, restarting server... (x2)
8:37:58 PM [vite] (client) info: Types generated for actions, routes, form variants
  Plugin: @laravel/vite-plugin-wayfinder
file:///Users/austin/Developer/repo/node_modules/laravel-vite-plugin/dist/index.js:1485
  return address.family === "IPv6" || address.family === 6;
                 ^

TypeError: Cannot read properties of null (reading 'family')
    at isIpv6 (file:///Users/austin/Developer/repo/node_modules/laravel-vite-plugin/dist/index.js:1485:18)
    at resolveDevServerUrl (file:///Users/austin/Developer/repo/node_modules/laravel-vite-plugin/dist/index.js:1478:25)
    at Http2SecureServer.<anonymous> (file:///Users/austin/Developer/repo/node_modules/laravel-vite-plugin/dist/index.js:1296:85)
    at Object.onceWrapper (node:events:622:28)
    at Http2SecureServer.emit (node:events:520:35)
    at emitListeningNT (node:net:1983:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:88:21)

Node.js v24.13.0
```