### PR TITLE
Prevent hot file cleanup when running Vitest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,10 @@ function resolveLaravelPlugin(pluginConfig: Required<PluginConfig>): LaravelPlug
             }
         },
         configureServer(server) {
+            if (process.env.VITEST !== undefined) {
+                return
+            }
+
             const envDir = resolvedConfig.envDir || process.cwd()
             const appUrl = loadEnv(resolvedConfig.mode, envDir, 'APP_URL').APP_URL ?? 'undefined'
 


### PR DESCRIPTION
When running the Vite dev server in a project that uses Vitest, `vitest` spins up a dev server, which runs this plugins hot file hooks, causing the hot file to be deleted at the end of the test run, even though the Vite dev server is still running separately.