### PR TITLE
[3.x] Combine font sources sharing a Unicode range

### DIFF
--- a/src/fonts/css.ts
+++ b/src/fonts/css.ts
@@ -21,8 +21,18 @@ export function generateFontFace(
         const rangedFiles = variant.files.filter(f => f.unicodeRange)
         const nonRangedFiles = variant.files.filter(f => ! f.unicodeRange)
 
+        // Files sharing a unicode-range are alternate sources for the same face,
+        // so preserve their order in a single src list.
+        const filesByRange = new Map<string, ResolvedFontFile[]>()
+
         for (const file of rangedFiles) {
-            const fileSrc = `url("${filePathMap.get(file.source) ?? file.source}") format("${formatKeyword(file.format)}")`
+            const range = file.unicodeRange!
+
+            filesByRange.set(range, [...filesByRange.get(range) ?? [], file])
+        }
+
+        for (const [unicodeRange, files] of filesByRange) {
+            const src = generateSrc(files, filePathMap)
 
             rules.push([
                 '@font-face {',
@@ -30,8 +40,8 @@ export function generateFontFace(
                 `  font-style: ${variant.style};`,
                 `  font-weight: ${String(variant.weight)};`,
                 `  font-display: ${family.display};`,
-                `  src: ${fileSrc};`,
-                `  unicode-range: ${file.unicodeRange};`,
+                `  src: ${src};`,
+                `  unicode-range: ${unicodeRange};`,
                 '}',
             ].join('\n'))
         }

--- a/tests/fonts-css.test.ts
+++ b/tests/fonts-css.test.ts
@@ -92,6 +92,30 @@ describe('fonts css generation', () => {
             expect(css).toContain('unicode-range: U+0100-024F')
         })
 
+        it('combines formats sharing a unicode-range into a single rule', () => {
+            const family = makeFamily({
+                variants: [{
+                    weight: 400,
+                    style: 'normal',
+                    files: [
+                        { source: '/fonts/inter-latin.woff2', format: 'woff2', unicodeRange: 'U+0000-00FF' },
+                        { source: '/fonts/inter-latin.woff', format: 'woff', unicodeRange: 'U+0000-00FF' },
+                    ],
+                }],
+            })
+
+            const filePathMap = new Map([
+                ['/fonts/inter-latin.woff2', 'assets/inter-latin.woff2'],
+                ['/fonts/inter-latin.woff', 'assets/inter-latin.woff'],
+            ])
+
+            const css = generateFontFace(family, filePathMap)
+
+            expect(css.match(/@font-face/g)).toHaveLength(1)
+            expect(css).toContain('src: url("assets/inter-latin.woff2") format("woff2"),\n    url("assets/inter-latin.woff") format("woff");')
+            expect(css.match(/unicode-range/g)).toHaveLength(1)
+        })
+
         it('uses spec-compliant format keywords for unicode-range files', () => {
             const family = makeFamily({
                 variants: [{


### PR DESCRIPTION
Fixes #389.

Groups font sources sharing a `unicode-range` into a single `@font-face` rule while preserving their source order. This prevents a preloaded WOFF2 source from being discarded in favor of WOFF.