### PR TITLE
fix(fonts): merge same-range formats into one @font-face src list

### DIFF
--- a/src/fonts/css.ts
+++ b/src/fonts/css.ts
@@ -21,17 +21,24 @@ export function generateFontFace(
         const rangedFiles = variant.files.filter(f => f.unicodeRange)
         const nonRangedFiles = variant.files.filter(f => ! f.unicodeRange)
 
-        for (const file of rangedFiles) {
-            const fileSrc = `url("${filePathMap.get(file.source) ?? file.source}") format("${formatKeyword(file.format)}")`
+        const rangedByRange = new Map<string, ResolvedFontFile[]>()
 
+        for (const file of rangedFiles) {
+            const files = rangedByRange.get(file.unicodeRange!) ?? []
+
+            files.push(file)
+            rangedByRange.set(file.unicodeRange!, files)
+        }
+
+        for (const [unicodeRange, files] of rangedByRange) {
             rules.push([
                 '@font-face {',
                 `  font-family: "${family.family}";`,
                 `  font-style: ${variant.style};`,
                 `  font-weight: ${String(variant.weight)};`,
                 `  font-display: ${family.display};`,
-                `  src: ${fileSrc};`,
-                `  unicode-range: ${file.unicodeRange};`,
+                `  src: ${generateSrc(files, filePathMap)};`,
+                `  unicode-range: ${unicodeRange};`,
                 '}',
             ].join('\n'))
         }

--- a/tests/fonts-css.test.ts
+++ b/tests/fonts-css.test.ts
@@ -92,6 +92,32 @@ describe('fonts css generation', () => {
             expect(css).toContain('unicode-range: U+0100-024F')
         })
 
+        it('merges formats of the same unicode range into one rule', () => {
+            const family = makeFamily({
+                variants: [{
+                    weight: 400,
+                    style: 'normal',
+                    files: [
+                        { source: '/fonts/inter-latin.woff2', format: 'woff2', unicodeRange: 'U+0000-00FF' },
+                        { source: '/fonts/inter-latin.woff', format: 'woff', unicodeRange: 'U+0000-00FF' },
+                    ],
+                }],
+            })
+
+            const css = generateFontFace(family, new Map([
+                ['/fonts/inter-latin.woff2', 'assets/inter-latin.woff2'],
+                ['/fonts/inter-latin.woff', 'assets/inter-latin.woff'],
+            ]))
+
+            // One rule with a format-fallback src list, matching the
+            // non-ranged path: browsers pick exactly one file instead of
+            // downloading a sibling rule per format.
+            expect(css.match(/@font-face/g)).toHaveLength(1)
+            expect(css).toContain('url("assets/inter-latin.woff2") format("woff2"),')
+            expect(css).toContain('url("assets/inter-latin.woff") format("woff")')
+            expect(css.match(/unicode-range: U\+0000-00FF/g)).toHaveLength(1)
+        })
+
         it('uses spec-compliant format keywords for unicode-range files', () => {
             const family = makeFamily({
                 variants: [{


### PR DESCRIPTION
### Problem

For font files carrying a `unicode-range` (every remote provider: `bunny()`, `google()`, `fontsource()`), `generateFontFace()` emits one `@font-face` rule per (range, format) file: a rule whose `src` holds only the `.woff2` file and a sibling rule with identical `font-family`, `font-style`, `font-weight`, `font-display`, and `unicode-range` holding only the `.woff` file.

Browsers fetch both files. Measured on a production Laravel 13 / Vite 8 build with Instrument Sans (weights 400/500/600, latin subset, `bunny()` provider): every cold page load downloads 3 `.woff2` files (51.5 KB) and all 3 `.woff` files (64.6 KB). The `.woff` payload is entirely redundant for any browser modern enough to run Vite's output, so about 56 percent of the font bytes are wasted on every load. The `<link rel="preload">` tags correctly list only the woff2 files.

The non-ranged path already does the right thing: `generateSrc()` merges all formats of a variant into one rule's `src` fallback list, and browsers pick exactly one file.

### Fix

Group ranged files by their `unicode-range` and emit one `@font-face` per (variant, range) with all of that range's formats merged into a single `src` list via the existing `generateSrc()`, exactly matching the non-ranged path.

Existing behavior is preserved: distinct ranges still produce distinct rules, mixed ranged/non-ranged variants still emit both, and format keywords are unchanged. Adds a regression test asserting that two formats of the same range collapse into one rule with a format-fallback `src`.

### Tests

`npm test`: 10 files, 328 passed (including the new regression test in `tests/fonts-css.test.ts`).

Note: the repository has issues disabled, so this arrives as a PR directly; happy to adjust approach or split anything out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)